### PR TITLE
test sign of changes fails

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: coseg
 Maintainer: Toby Dylan Hocking <tdhock5@gmail.com>
 Author: Toby Dylan Hocking
-Version: 2016.07.13
+Version: 2016.08.02
 License: GPL-3
 Title: Constrained Optimal Segmentation
 Description: Computes optimal segmentations subject to constraints

--- a/NEWS
+++ b/NEWS
@@ -17,8 +17,10 @@ by the R function PeakSegFPOP.
 Bugfix in min_more computation for intersections between constant cost
 and degenerate linear cost.
 
-Bugfix in Minimize: we need to consider an upper or lower bound, even
-when the equality constraint is not active.
+Bugfix in decoding: we no longer call Minimize for segments other than
+the last one. Now we store the previous segment mean (which was
+already computed by the min-less/more operator). No more bool
+equality_constraint_active, instead test prev_seg_mean == INFINITY.
 
 2016.07.13
 

--- a/NEWS
+++ b/NEWS
@@ -4,7 +4,18 @@ Limited memory FPOP version. What serialization/file format to use for
 reading data (bigwig/bedGraph?) and storing the optimal cost
 functions?
 
-Regularized isotonic regression solver.
+Regularized isotonic regression solver, square loss and penalized
+(FPOP) parameterization.
+
+2016.08.xx
+
+PeakSegFPOPall C++ function which can start or end either up or down.
+
+PeakSegFPOPLog C++ function forces starts and ends down. This is used
+by the R function PeakSegFPOP.
+
+Bugfix in min_more computation for intersections between constant cost
+and degenerate linear cost.
 
 2016.07.13
 

--- a/NEWS
+++ b/NEWS
@@ -7,7 +7,10 @@ functions?
 Regularized isotonic regression solver, square loss and penalized
 (FPOP) parameterization.
 
-2016.08.xx
+To avoid root finding problems in large data sets, try storing mean
+cost rather than total cost.
+
+2016.08.02
 
 PeakSegFPOPall C++ function which can start or end either up or down.
 

--- a/NEWS
+++ b/NEWS
@@ -17,6 +17,9 @@ by the R function PeakSegFPOP.
 Bugfix in min_more computation for intersections between constant cost
 and degenerate linear cost.
 
+Bugfix in Minimize: we need to consider an upper or lower bound, even
+when the equality constraint is not active.
+
 2016.07.13
 
 FPOP version of PeakSeg constrained, Poisson loss problem.

--- a/R/PeakSegFPOP.R
+++ b/R/PeakSegFPOP.R
@@ -58,6 +58,7 @@ PeakSegFPOP <- structure(function
 ### segment means), intervals.mat (number of intervals stored by the
 ### functional pruning algorithm), label.vec (1=up or 0=down).
 }, ex=function(){
+
   library(coseg)
   data("H3K4me3_XJ_immune_chunk1")
   by.sample <-
@@ -79,6 +80,7 @@ PeakSegFPOP <- structure(function
     geom_line(aes(data, intervals), data=FPOP.intervals)+
     scale_y_continuous(
       "intervals stored by the\nconstrained optimal segmentation algorithm")
+
 })
 
 PeakSegFPOPchrom <- structure(function
@@ -141,10 +143,10 @@ PeakSegFPOPchrom <- structure(function
   by.sample <-
     split(H3K4me3_XJ_immune_chunk1, H3K4me3_XJ_immune_chunk1$sample.id)
   one.sample <- by.sample[[sample.id]]
-  penalty.constant <- 2000
+
+  penalty.constant <- 1100
   fpop.fit <- PeakSegFPOPchrom(one.sample, penalty.constant)
   fpop.breaks <- subset(fpop.fit$segments, 1 < first)
-
   library(ggplot2)
   ggplot()+
     theme_bw()+
@@ -162,13 +164,16 @@ PeakSegFPOPchrom <- structure(function
 
   max.peaks <- as.integer(fpop.fit$segments$peaks[1]+1)
   pdpa.fit <- PeakSegPDPAchrom(one.sample, max.peaks)
-  models <- pdpa.fit$modelSelection
-  models$PoissonLoss <- rev(pdpa.fit$loss$PoissonLoss)
+  models <- pdpa.fit$modelSelection.decreasing
+  models$PoissonLoss <- pdpa.fit$loss[paste(models$peaks), "PoissonLoss"]
   models$algorithm <- "PDPA"
   fpop.fit$loss$algorithm <- "FPOP"
   ggplot()+
-    geom_abline(aes(slope=segments-1, intercept=PoissonLoss, color=peaks),
+    geom_abline(aes(slope=peaks, intercept=PoissonLoss, color=peaks),
                 data=pdpa.fit$loss)+
+    geom_text(aes(0, PoissonLoss, label=peaks),
+              hjust=1,
+              data=pdpa.fit$loss)+
     geom_point(aes(penalty.constant, penalized.loss, fill=algorithm),
                shape=21,
                data=fpop.fit$loss)+

--- a/R/PeakSegFPOP.R
+++ b/R/PeakSegFPOP.R
@@ -1,27 +1,26 @@
 PeakSegFPOP <- structure(function
 ### Find the optimal change-points using the Poisson loss and the
 ### PeakSeg constraint. For N data points, the functional pruning
-### algorithm is O(N) space and O(NlogN) time. It recovers the exact
+### algorithm is O(N) space and O(N log N) time. It recovers the exact
 ### solution to the following optimization problem. Let Z be an
 ### N-vector of count data (non-negative integers). Find the N-vector
 ### M of real numbers (segment means) which minimize the penalized
-### Poisson Loss, sum_{i=2}^N I(m_i != m_{i-1})*penalty + sum_{i=1}^N
+### Poisson Loss, sum_{i=2}^N I(m_{i-1} < m_i)*penalty + sum_{i=1}^N
 ### m_i - z_i * log(m_i), subject to constraint: up changes are
 ### followed by down changes, and vice versa. Note that the segment
 ### means can be equal, in which case the recovered model is not
-### feasible for the PeakSeg problem. Unlike PeakSegPDPA which forces
-### the first segment mean to be down (mu1 <= mu2), PeakSegFPOP may
-### recover a model with the first segment mean up (mu1 >= mu2).
+### feasible for the PeakSeg problem. This function constrains the
+### first and last segment means to be down, mu_1 <= mu_2, mu_{N-1} >= mu_N).
 (count.vec,
-### integer vector of count data.
+### integer vector of length >= 3: count data to segment.
  weight.vec=rep(1, length(count.vec)),
 ### numeric vector (same length as count.vec) of positive weights.
  penalty=NULL
-### numeric of length 1: penalty parameter (smaller for more peaks,
-### larger for fewer peaks).
+### non-negative numeric scalar: penalty parameter (smaller for more
+### peaks, larger for fewer peaks).
 ){
   n.data <- length(count.vec)
-  stopifnot(1 < n.data)
+  stopifnot(3 <= n.data)
   stopifnot(is.integer(count.vec))
   stopifnot(is.numeric(weight.vec))
   stopifnot(n.data==length(weight.vec))
@@ -56,7 +55,7 @@ PeakSegFPOP <- structure(function
 ### (input parameters), cost.mat (optimal Poisson loss), ends.vec
 ### (optimal position of segment ends, 1-indexed), mean.vec (optimal
 ### segment means), intervals.mat (number of intervals stored by the
-### functional pruning algorithm), label.vec (1=up or 0=down).
+### functional pruning algorithm).
 }, ex=function(){
 
   library(coseg)
@@ -90,11 +89,12 @@ PeakSegFPOPchrom <- structure(function
 (count.df,
 ### data.frame with columns count, chromStart, chromEnd.
  penalty=NULL
-### integer > 0: maximum number of peaks.
+### non-negative numeric scalar: penalty parameter (smaller for more
+### peaks, larger for fewer peaks).
 ){
   stopifnot(is.data.frame(count.df))
   n.data <- nrow(count.df)
-  stopifnot(1 < n.data)
+  stopifnot(3 <= n.data)
   stopifnot(is.integer(count.df$chromStart))
   stopifnot(is.integer(count.df$chromEnd))
   stopifnot(is.integer(count.df$count))

--- a/R/PeakSegFPOP.R
+++ b/R/PeakSegFPOP.R
@@ -33,7 +33,6 @@ PeakSegFPOP <- structure(function
   ends.vec <- integer(n.data)
   mean.vec <- double(n.data)
   intervals.mat <- integer(n.data*2)
-  label.vec <- integer(n.data)
   result.list <- .C(
     "PeakSegFPOPLog_interface",
     count.vec=as.integer(count.vec),
@@ -44,7 +43,7 @@ PeakSegFPOP <- structure(function
     ends.vec=as.integer(ends.vec),
     mean.vec=as.double(mean.vec),
     intervals.mat=as.integer(intervals.mat),
-    label.vec=as.integer(label.vec),
+    ##label.vec=as.integer(label.vec),
     PACKAGE="coseg")
   ## 1-indexed segment ends!
   result.list$ends.vec <- result.list$ends.vec+1L
@@ -108,7 +107,8 @@ PeakSegFPOPchrom <- structure(function
   break.vec <- rev(fit$ends.vec[0<fit$ends.vec])
   first <- c(1, break.vec+1)
   last <- c(break.vec, nrow(count.df))
-  label.vec <- rev(fit$label.vec[0 <= fit$label.vec])
+  ##label.vec <- rev(fit$label.vec[0 <= fit$label.vec])
+  label.vec <- rep(c(0, 1), l=sum(is.finite(fit$mean.vec)))
   status.str <- ifelse(label.vec==0, "background", "peak")
   peaks <- sum(label.vec==1)
   mean.vec <- rev(fit$mean.vec[is.finite(fit$mean.vec)])

--- a/R/PeakSegPDPA.R
+++ b/R/PeakSegPDPA.R
@@ -56,6 +56,7 @@ PeakSegPDPA <- structure(function
 ### (optimal segment means), intervals.mat (number of intervals stored
 ### by the functional pruning algorithm).
 }, ex=function(){
+
   data("H3K4me3_XJ_immune_chunk1")
   by.sample <-
     split(H3K4me3_XJ_immune_chunk1, H3K4me3_XJ_immune_chunk1$sample.id)
@@ -79,6 +80,7 @@ PeakSegPDPA <- structure(function
     scale_y_continuous(
       "intervals stored by the\nconstrained optimal segmentation algorithm",
       breaks=c(20, 40))
+  
 })
 
 PeakSegPDPAchrom <- structure(function
@@ -148,8 +150,10 @@ PeakSegPDPAchrom <- structure(function
     modelSelection.decreasing=dec.models)
 ### List of data.frames: segments can be used for plotting the
 ### segmentation model, loss describes model loss and feasibility,
-### modelSelection describes the set of all linear penalty (lambda)
-### values which can be used to select the feasible models.
+### modelSelection.feasible describes the set of all linear penalty
+### (lambda) values which can be used to select the feasible models,
+### modelSelection.decreasing selects from all models that decrease
+### the Poisson loss relative to simpler models (same as PeakSegFPOP).
 }, ex=function(){
 
   ## samples for which pdpa recovers a more likely model, but it is

--- a/R/PeakSegPDPA.R
+++ b/R/PeakSegPDPA.R
@@ -140,7 +140,7 @@ PeakSegPDPAchrom <- structure(function
     segments=seg.df,
     loss=loss.df,
     modelSelection=with(only.feasible, {
-      exactModelSelection(PoissonLoss, segments-1, peaks)
+      exactModelSelection(PoissonLoss, peaks, peaks)
     }))
 ### List of data.frames: segments can be used for plotting the
 ### segmentation model, loss describes model loss and feasibility,

--- a/R/PeakSegPDPA.R
+++ b/R/PeakSegPDPA.R
@@ -133,15 +133,19 @@ PeakSegPDPAchrom <- structure(function
     peaks=(seg.vec-1)/2,
     PoissonLoss=fit$cost.mat[seg.vec, length(data.vec)],
     feasible=apply(fit$mean.mat[seg.vec,], 1, is.feasible))
+  rownames(loss.df) <- loss.df$peaks
   seg.df <- do.call(rbind, segments.list)
   only.feasible <- loss.df[loss.df$feasible,]
   rownames(seg.df) <- NULL
+  dec.loss <- subset(loss.df, c(TRUE, diff(PoissonLoss) < 0))
+  dec.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
   list(
     segments=seg.df,
     loss=loss.df,
-    modelSelection=with(only.feasible, {
+    modelSelection.feasible=with(only.feasible, {
       exactModelSelection(PoissonLoss, peaks, peaks)
-    }))
+    }),
+    modelSelection.decreasing=dec.models)
 ### List of data.frames: segments can be used for plotting the
 ### segmentation model, loss describes model loss and feasibility,
 ### modelSelection describes the set of all linear penalty (lambda)

--- a/man/PeakSegFPOP.Rd
+++ b/man/PeakSegFPOP.Rd
@@ -35,6 +35,7 @@ functional pruning algorithm), label.vec (1=up or 0=down).}
 
 
 \examples{
+
 library(coseg)
 data("H3K4me3_XJ_immune_chunk1")
 by.sample <-
@@ -56,4 +57,5 @@ ggplot()+
   geom_line(aes(data, intervals), data=FPOP.intervals)+
   scale_y_continuous(
     "intervals stored by the\nconstrained optimal segmentation algorithm")
+
 }

--- a/man/PeakSegFPOP.Rd
+++ b/man/PeakSegFPOP.Rd
@@ -3,31 +3,30 @@
 \title{PeakSegFPOP}
 \description{Find the optimal change-points using the Poisson loss and the
 PeakSeg constraint. For N data points, the functional pruning
-algorithm is O(N) space and O(NlogN) time. It recovers the exact
+algorithm is O(N) space and O(N log N) time. It recovers the exact
 solution to the following optimization problem. Let Z be an
 N-vector of count data (non-negative integers). Find the N-vector
 M of real numbers (segment means) which minimize the penalized
-Poisson Loss, sum_{i=2}^N I(m_i != m_{i-1})*penalty + sum_{i=1}^N
+Poisson Loss, sum_{i=2}^N I(m_{i-1} < m_i)*penalty + sum_{i=1}^N
 m_i - z_i * log(m_i), subject to constraint: up changes are
 followed by down changes, and vice versa. Note that the segment
 means can be equal, in which case the recovered model is not
-feasible for the PeakSeg problem. Unlike PeakSegPDPA which forces
-the first segment mean to be down (mu1 <= mu2), PeakSegFPOP may
-recover a model with the first segment mean up (mu1 >= mu2).}
+feasible for the PeakSeg problem. This function constrains the
+first and last segment means to be down, mu_1 <= mu_2, mu_{N-1} >= mu_N).}
 \usage{PeakSegFPOP(count.vec, weight.vec = rep(1, length(count.vec)), 
     penalty = NULL)}
 \arguments{
-  \item{count.vec}{integer vector of count data.}
+  \item{count.vec}{integer vector of length >= 3: count data to segment.}
   \item{weight.vec}{numeric vector (same length as count.vec) of positive weights.}
-  \item{penalty}{numeric of length 1: penalty parameter (smaller for more peaks,
-larger for fewer peaks).}
+  \item{penalty}{non-negative numeric scalar: penalty parameter (smaller for more
+peaks, larger for fewer peaks).}
 }
 
 \value{List of model parameters. count.vec, weight.vec, n.data, penalty
 (input parameters), cost.mat (optimal Poisson loss), ends.vec
 (optimal position of segment ends, 1-indexed), mean.vec (optimal
 segment means), intervals.mat (number of intervals stored by the
-functional pruning algorithm), label.vec (1=up or 0=down).}
+functional pruning algorithm).}
 
 \author{Toby Dylan Hocking}
 

--- a/man/PeakSegFPOPchrom.Rd
+++ b/man/PeakSegFPOPchrom.Rd
@@ -7,7 +7,8 @@ the PeakSegFPOP function.}
 \usage{PeakSegFPOPchrom(count.df, penalty = NULL)}
 \arguments{
   \item{count.df}{data.frame with columns count, chromStart, chromEnd.}
-  \item{penalty}{integer > 0: maximum number of peaks.}
+  \item{penalty}{non-negative numeric scalar: penalty parameter (smaller for more
+peaks, larger for fewer peaks).}
 }
 
 \value{List of data.frames: segments can be used for plotting the

--- a/man/PeakSegFPOPchrom.Rd
+++ b/man/PeakSegFPOPchrom.Rd
@@ -28,10 +28,10 @@ H3K4me3_XJ_immune_chunk1$count <- H3K4me3_XJ_immune_chunk1$coverage
 by.sample <-
   split(H3K4me3_XJ_immune_chunk1, H3K4me3_XJ_immune_chunk1$sample.id)
 one.sample <- by.sample[[sample.id]]
-penalty.constant <- 2000
+
+penalty.constant <- 1100
 fpop.fit <- PeakSegFPOPchrom(one.sample, penalty.constant)
 fpop.breaks <- subset(fpop.fit$segments, 1 < first)
-
 library(ggplot2)
 ggplot()+
   theme_bw()+
@@ -49,13 +49,16 @@ ggplot()+
 
 max.peaks <- as.integer(fpop.fit$segments$peaks[1]+1)
 pdpa.fit <- PeakSegPDPAchrom(one.sample, max.peaks)
-models <- pdpa.fit$modelSelection
-models$PoissonLoss <- rev(pdpa.fit$loss$PoissonLoss)
+models <- pdpa.fit$modelSelection.decreasing
+models$PoissonLoss <- pdpa.fit$loss[paste(models$peaks), "PoissonLoss"]
 models$algorithm <- "PDPA"
 fpop.fit$loss$algorithm <- "FPOP"
 ggplot()+
-  geom_abline(aes(slope=segments-1, intercept=PoissonLoss, color=peaks),
+  geom_abline(aes(slope=peaks, intercept=PoissonLoss, color=peaks),
               data=pdpa.fit$loss)+
+  geom_text(aes(0, PoissonLoss, label=peaks),
+            hjust=1,
+            data=pdpa.fit$loss)+
   geom_point(aes(penalty.constant, penalized.loss, fill=algorithm),
              shape=21,
              data=fpop.fit$loss)+

--- a/man/PeakSegPDPA.Rd
+++ b/man/PeakSegPDPA.Rd
@@ -33,6 +33,7 @@ by the functional pruning algorithm).}
 
 
 \examples{
+
 data("H3K4me3_XJ_immune_chunk1")
 by.sample <-
   split(H3K4me3_XJ_immune_chunk1, H3K4me3_XJ_immune_chunk1$sample.id)
@@ -56,4 +57,5 @@ ggplot()+
   scale_y_continuous(
     "intervals stored by the\nconstrained optimal segmentation algorithm",
     breaks=c(20, 40))
+
 }

--- a/man/PeakSegPDPAchrom.Rd
+++ b/man/PeakSegPDPAchrom.Rd
@@ -12,8 +12,10 @@ the PeakSegPDPA function.}
 
 \value{List of data.frames: segments can be used for plotting the
 segmentation model, loss describes model loss and feasibility,
-modelSelection describes the set of all linear penalty (lambda)
-values which can be used to select the feasible models.}
+modelSelection.feasible describes the set of all linear penalty
+(lambda) values which can be used to select the feasible models,
+modelSelection.decreasing selects from all models that decrease
+the Poisson loss relative to simpler models (same as PeakSegFPOP).}
 
 \author{Toby Dylan Hocking}
 

--- a/src/PeakSegFPOPLog.cpp
+++ b/src/PeakSegFPOPLog.cpp
@@ -141,32 +141,45 @@ void PeakSegFPOPLog
     intervals_mat[i] = up_cost->piece_list.size();
     up_cost->Minimize
       (cost_mat+i, &best_log_mean,
-       &prev_seg_end, &equality_constraint_active);
+       &prev_seg_end, &equality_constraint_active,
+       min_log_mean, max_log_mean);
   }
+  // last segment is down (offset N) so the second to last segment is
+  // up (offset 0).
   int prev_seg_offset = 0;
   down_cost = &cost_model_mat[data_count*2-1];
   down_cost->Minimize
     (&best_cost, &best_log_mean,
-     &prev_seg_end, &equality_constraint_active);
+     &prev_seg_end, &equality_constraint_active,
+     min_log_mean, max_log_mean);
   mean_vec[0] = exp(best_log_mean);
   end_vec[0] = prev_seg_end;
   int out_i=1;
   while(0 <= prev_seg_end){
-    //printf("decoding out_i=%d prev_seg_end=%d prev_seg_offset=%d\n", out_i, prev_seg_end, prev_seg_offset);
+    // up_cost is actually either an up or down cost.
     up_cost = &cost_model_mat[prev_seg_offset + prev_seg_end];
+    //printf("decoding out_i=%d prev_seg_end=%d prev_seg_offset=%d\n", out_i, prev_seg_end, prev_seg_offset);
     //up_cost->print();
+    double this_min, this_max;
+    if(prev_seg_offset==0){
+      //up_cost is actually up, minimization needs a lower bound.
+      prev_seg_offset = data_count;
+      this_min = best_log_mean;
+      this_max = max_log_mean;
+    }else{
+      //up_cost is actually down, minimization needs an upper bound.
+      prev_seg_offset = 0;
+      this_min = min_log_mean;
+      this_max = best_log_mean;
+    }
     if(equality_constraint_active){
       up_cost->findMean
 	(best_log_mean, &prev_seg_end, &equality_constraint_active);
     }else{
       up_cost->Minimize
 	(&best_cost, &best_log_mean,
-	 &prev_seg_end, &equality_constraint_active);
-    }
-    if(prev_seg_offset==0){
-      prev_seg_offset = data_count;
-    }else{
-      prev_seg_offset = 0;
+	 &prev_seg_end, &equality_constraint_active,
+	 this_min, this_max);
     }
     mean_vec[out_i] = exp(best_log_mean);
     end_vec[out_i] = prev_seg_end;
@@ -174,133 +187,133 @@ void PeakSegFPOPLog
   }//for(data_i
 }
 
-void PeakSegFPOPall
-(int *data_vec, double *weight_vec, int data_count,
- double penalty,
- // the following matrices are for output.
- // cost_mat and intervals_mat store the optimal cost and number of intervals
- // at each time point, for the up and down cost models.
- // end_vec and mean_vec store the best model up to and including the
- // last data point. 
- double *cost_mat, //data_count x 2.
- int *end_vec, //data_count
- double *mean_vec,//data_count
- int *intervals_mat,//data_count x 2
- int *label_vec){//data_count
-  double min_log_mean=log(data_vec[0]), max_log_mean=log(data_vec[0]);
-  for(int data_i=1; data_i<data_count; data_i++){
-    double log_data = log(data_vec[data_i]);
-    if(log_data < min_log_mean){
-      min_log_mean = log_data;
-    }
-    if(max_log_mean < log_data){
-      max_log_mean = log_data;
-    }
-  }
-  std::vector<PiecewisePoissonLossLog> cost_model_mat(data_count * 2);
-  PiecewisePoissonLossLog *up_cost, *down_cost, *up_cost_prev, *down_cost_prev;
-  PiecewisePoissonLossLog min_prev_cost;
-  int verbose=0;
-  for(int data_i=0; data_i<data_count; data_i++){
-    //printf("computing cost data_i=%d\n", data_i);
-    up_cost = &cost_model_mat[data_i];
-    down_cost = &cost_model_mat[data_i + data_count]; 
-    if(data_i==0){
-      // initialization C_1(m)=gamma_1(m)
-      up_cost->piece_list.emplace_back
-	(weight_vec[0], -data_vec[0]*weight_vec[0], 0.0,
-	 min_log_mean, max_log_mean, -1, false);
-      down_cost->piece_list.emplace_back
-	(weight_vec[0], -data_vec[0]*weight_vec[0], 0.0,
-	 min_log_mean, max_log_mean, -1, false);
-    }else{
-      // if data_i is up, it could have come from down_cost_prev.
-      min_prev_cost.set_to_min_less_of(down_cost_prev, verbose);
-      min_prev_cost.set_prev_seg_end(data_i-1);
-      min_prev_cost.add(0.0, 0.0, penalty);
-      up_cost->set_to_min_env_of(&min_prev_cost, up_cost_prev, verbose);
-      up_cost->add
-	(weight_vec[data_i],
-	 -data_vec[data_i]*weight_vec[data_i],
-	 0.0);
-      // if data_i is down, it could have come from up_cost_prev.
-      min_prev_cost.set_to_min_more_of(up_cost_prev, verbose);
-      min_prev_cost.set_prev_seg_end(data_i-1);
-      min_prev_cost.add(0.0, 0.0, penalty);
-      down_cost->set_to_min_env_of(&min_prev_cost, down_cost_prev, verbose);
-      down_cost->add
-	(weight_vec[data_i],
-	 -data_vec[data_i]*weight_vec[data_i],
-	 0.0);
-    }
-    up_cost_prev = up_cost;
-    down_cost_prev = down_cost;
-  }
-  // Decoding the cost_model_vec, and writing to the output matrices.
-  double best_cost, best_log_mean, candidate_cost, candidate_log_mean;
-  bool equality_constraint_active, candidate_constraint;
-  int prev_seg_end=data_count, candidate_end;
-  for(int i=0; i<data_count; i++){
-    mean_vec[i] = INFINITY;
-    end_vec[i] = -2;
-    label_vec[i] = -1;
-  }
-  for(int i=0; i<2*data_count; i++){
-    up_cost = &cost_model_mat[i];
-    intervals_mat[i] = up_cost->piece_list.size();
-    up_cost->Minimize
-      (cost_mat+i, &best_log_mean,
-       &prev_seg_end, &equality_constraint_active);
-  }
-  int prev_seg_offset;
-  up_cost = &cost_model_mat[data_count-1];
-  up_cost->Minimize
-    (&candidate_cost, &candidate_log_mean,
-     &candidate_end, &candidate_constraint);
-  //printf("final up cost=%f at log_mean=%f\n", candidate_cost, candidate_log_mean);
-  //up_cost->print();
-  down_cost = &cost_model_mat[data_count*2-1];
-  down_cost->Minimize
-    (&best_cost, &best_log_mean,
-     &prev_seg_end, &equality_constraint_active);
-  //printf("final down cost=%f at log_mean=%f\n", best_cost, best_log_mean);
-  //down_cost->print();
-  if(candidate_cost < best_cost){
-    //more likely to end up, so previous segment was down.
-    best_cost = candidate_cost;
-    best_log_mean = candidate_log_mean;
-    prev_seg_end = candidate_end;
-    equality_constraint_active = candidate_constraint;
-    prev_seg_offset = data_count;
-    label_vec[0] = 1;
-  }else{
-    prev_seg_offset = 0;
-    label_vec[0] = 0;
-  }
-  mean_vec[0] = exp(best_log_mean);
-  end_vec[0] = prev_seg_end;
-  int out_i=1;
-  while(0 <= prev_seg_end){
-    //printf("decoding out_i=%d prev_seg_end=%d prev_seg_offset=%d\n", out_i, prev_seg_end, prev_seg_offset);
-    up_cost = &cost_model_mat[prev_seg_offset + prev_seg_end];
-    //up_cost->print();
-    if(equality_constraint_active){
-      up_cost->findMean
-	(best_log_mean, &prev_seg_end, &equality_constraint_active);
-    }else{
-      up_cost->Minimize
-	(&best_cost, &best_log_mean,
-	 &prev_seg_end, &equality_constraint_active);
-    }
-    if(prev_seg_offset==0){
-      prev_seg_offset = data_count;
-      label_vec[out_i] = 1;
-    }else{
-      prev_seg_offset = 0;
-      label_vec[out_i] = 0;
-    }
-    mean_vec[out_i] = exp(best_log_mean);
-    end_vec[out_i] = prev_seg_end;
-    out_i++;
-  }//for(data_i
-}
+// void PeakSegFPOPall
+// (int *data_vec, double *weight_vec, int data_count,
+//  double penalty,
+//  // the following matrices are for output.
+//  // cost_mat and intervals_mat store the optimal cost and number of intervals
+//  // at each time point, for the up and down cost models.
+//  // end_vec and mean_vec store the best model up to and including the
+//  // last data point. 
+//  double *cost_mat, //data_count x 2.
+//  int *end_vec, //data_count
+//  double *mean_vec,//data_count
+//  int *intervals_mat,//data_count x 2
+//  int *label_vec){//data_count
+//   double min_log_mean=log(data_vec[0]), max_log_mean=log(data_vec[0]);
+//   for(int data_i=1; data_i<data_count; data_i++){
+//     double log_data = log(data_vec[data_i]);
+//     if(log_data < min_log_mean){
+//       min_log_mean = log_data;
+//     }
+//     if(max_log_mean < log_data){
+//       max_log_mean = log_data;
+//     }
+//   }
+//   std::vector<PiecewisePoissonLossLog> cost_model_mat(data_count * 2);
+//   PiecewisePoissonLossLog *up_cost, *down_cost, *up_cost_prev, *down_cost_prev;
+//   PiecewisePoissonLossLog min_prev_cost;
+//   int verbose=0;
+//   for(int data_i=0; data_i<data_count; data_i++){
+//     //printf("computing cost data_i=%d\n", data_i);
+//     up_cost = &cost_model_mat[data_i];
+//     down_cost = &cost_model_mat[data_i + data_count]; 
+//     if(data_i==0){
+//       // initialization C_1(m)=gamma_1(m)
+//       up_cost->piece_list.emplace_back
+// 	(weight_vec[0], -data_vec[0]*weight_vec[0], 0.0,
+// 	 min_log_mean, max_log_mean, -1, false);
+//       down_cost->piece_list.emplace_back
+// 	(weight_vec[0], -data_vec[0]*weight_vec[0], 0.0,
+// 	 min_log_mean, max_log_mean, -1, false);
+//     }else{
+//       // if data_i is up, it could have come from down_cost_prev.
+//       min_prev_cost.set_to_min_less_of(down_cost_prev, verbose);
+//       min_prev_cost.set_prev_seg_end(data_i-1);
+//       min_prev_cost.add(0.0, 0.0, penalty);
+//       up_cost->set_to_min_env_of(&min_prev_cost, up_cost_prev, verbose);
+//       up_cost->add
+// 	(weight_vec[data_i],
+// 	 -data_vec[data_i]*weight_vec[data_i],
+// 	 0.0);
+//       // if data_i is down, it could have come from up_cost_prev.
+//       min_prev_cost.set_to_min_more_of(up_cost_prev, verbose);
+//       min_prev_cost.set_prev_seg_end(data_i-1);
+//       min_prev_cost.add(0.0, 0.0, penalty);
+//       down_cost->set_to_min_env_of(&min_prev_cost, down_cost_prev, verbose);
+//       down_cost->add
+// 	(weight_vec[data_i],
+// 	 -data_vec[data_i]*weight_vec[data_i],
+// 	 0.0);
+//     }
+//     up_cost_prev = up_cost;
+//     down_cost_prev = down_cost;
+//   }
+//   // Decoding the cost_model_vec, and writing to the output matrices.
+//   double best_cost, best_log_mean, candidate_cost, candidate_log_mean;
+//   bool equality_constraint_active, candidate_constraint;
+//   int prev_seg_end=data_count, candidate_end;
+//   for(int i=0; i<data_count; i++){
+//     mean_vec[i] = INFINITY;
+//     end_vec[i] = -2;
+//     label_vec[i] = -1;
+//   }
+//   for(int i=0; i<2*data_count; i++){
+//     up_cost = &cost_model_mat[i];
+//     intervals_mat[i] = up_cost->piece_list.size();
+//     up_cost->Minimize
+//       (cost_mat+i, &best_log_mean,
+//        &prev_seg_end, &equality_constraint_active);
+//   }
+//   int prev_seg_offset;
+//   up_cost = &cost_model_mat[data_count-1];
+//   up_cost->Minimize
+//     (&candidate_cost, &candidate_log_mean,
+//      &candidate_end, &candidate_constraint);
+//   //printf("final up cost=%f at log_mean=%f\n", candidate_cost, candidate_log_mean);
+//   //up_cost->print();
+//   down_cost = &cost_model_mat[data_count*2-1];
+//   down_cost->Minimize
+//     (&best_cost, &best_log_mean,
+//      &prev_seg_end, &equality_constraint_active);
+//   //printf("final down cost=%f at log_mean=%f\n", best_cost, best_log_mean);
+//   //down_cost->print();
+//   if(candidate_cost < best_cost){
+//     //more likely to end up, so previous segment was down.
+//     best_cost = candidate_cost;
+//     best_log_mean = candidate_log_mean;
+//     prev_seg_end = candidate_end;
+//     equality_constraint_active = candidate_constraint;
+//     prev_seg_offset = data_count;
+//     label_vec[0] = 1;
+//   }else{
+//     prev_seg_offset = 0;
+//     label_vec[0] = 0;
+//   }
+//   mean_vec[0] = exp(best_log_mean);
+//   end_vec[0] = prev_seg_end;
+//   int out_i=1;
+//   while(0 <= prev_seg_end){
+//     //printf("decoding out_i=%d prev_seg_end=%d prev_seg_offset=%d\n", out_i, prev_seg_end, prev_seg_offset);
+//     up_cost = &cost_model_mat[prev_seg_offset + prev_seg_end];
+//     //up_cost->print();
+//     if(equality_constraint_active){
+//       up_cost->findMean
+// 	(best_log_mean, &prev_seg_end, &equality_constraint_active);
+//     }else{
+//       up_cost->Minimize
+// 	(&best_cost, &best_log_mean,
+// 	 &prev_seg_end, &equality_constraint_active);
+//     }
+//     if(prev_seg_offset==0){
+//       prev_seg_offset = data_count;
+//       label_vec[out_i] = 1;
+//     }else{
+//       prev_seg_offset = 0;
+//       label_vec[out_i] = 0;
+//     }
+//     mean_vec[out_i] = exp(best_log_mean);
+//     end_vec[out_i] = prev_seg_end;
+//     out_i++;
+//   }//for(data_i
+// }

--- a/src/PeakSegFPOPLog.cpp
+++ b/src/PeakSegFPOPLog.cpp
@@ -16,6 +16,175 @@ void PeakSegFPOPLog
  double *cost_mat, //data_count x 2.
  int *end_vec, //data_count
  double *mean_vec,//data_count
+ int *intervals_mat){//data_count x 2
+  double min_log_mean=log(data_vec[0]), max_log_mean=log(data_vec[0]);
+  for(int data_i=1; data_i<data_count; data_i++){
+    double log_data = log(data_vec[data_i]);
+    if(log_data < min_log_mean){
+      min_log_mean = log_data;
+    }
+    if(max_log_mean < log_data){
+      max_log_mean = log_data;
+    }
+  }
+  std::vector<PiecewisePoissonLossLog> cost_model_mat(data_count * 2);
+  PiecewisePoissonLossLog *up_cost, *down_cost, *up_cost_prev, *down_cost_prev;
+  PiecewisePoissonLossLog min_prev_cost;
+  int verbose=0;
+  for(int data_i=0; data_i<data_count; data_i++){
+    up_cost = &cost_model_mat[data_i];
+    down_cost = &cost_model_mat[data_i + data_count]; 
+    if(data_i==0){
+      // initialization Cdown_1(m)=gamma_1(m)
+      down_cost->piece_list.emplace_back
+	(weight_vec[0], -data_vec[0]*weight_vec[0], 0.0,
+	 min_log_mean, max_log_mean, -1, false);
+    }else if(data_i==1){      
+      // initialization Cup_2(m)=Cdown_1(m)+penalty+gamma_2(m)
+      up_cost->set_to_min_less_of(down_cost_prev, verbose);
+      up_cost->set_prev_seg_end(data_i-1);
+      up_cost->add
+	(weight_vec[data_i],
+	 -data_vec[data_i]*weight_vec[data_i],
+	 penalty);
+      // initialization Cdown_2(m)=gamma_1(m)+gamma_2(m)
+      down_cost->piece_list.emplace_back
+	(weight_vec[0], -data_vec[0]*weight_vec[0], 0.0,
+	 min_log_mean, max_log_mean, -1, false);
+      down_cost->add
+	(weight_vec[data_i],
+	 -data_vec[data_i]*weight_vec[data_i],
+	 0.0);
+    }else{
+      // if data_i is up, it could have come from down_cost_prev.
+      min_prev_cost.set_to_min_less_of(down_cost_prev, verbose);
+      int status = min_prev_cost.check_min_of(down_cost_prev, down_cost_prev);
+      if(status){
+	printf("BAD MIN LESS CHECK data_i=%d status=%d\n", data_i, status);
+	printf("prev down cost\n");
+	down_cost_prev->print();
+	printf("min less(prev down cost)\n");
+	min_prev_cost.print();
+	throw status;
+      }
+      min_prev_cost.set_prev_seg_end(data_i-1);
+      min_prev_cost.add(0.0, 0.0, penalty);
+      up_cost->set_to_min_env_of(&min_prev_cost, up_cost_prev, verbose);
+      status = up_cost->check_min_of(&min_prev_cost, up_cost_prev);
+      if(status){
+	printf("BAD MIN ENV CHECK data_i=%d status=%d\n", data_i, status);
+	printf("prev down cost\n");
+	down_cost_prev->print();
+	printf("min less(prev down cost) + %f\n", penalty);
+	min_prev_cost.print();
+	printf("prev up cost\n");
+	up_cost_prev->print();
+	printf("new up cost model\n");
+	up_cost->print();
+	throw status;
+      }
+      up_cost->add
+	(weight_vec[data_i],
+	 -data_vec[data_i]*weight_vec[data_i],
+	 0.0);
+      // if data_i is down, it could have come from up_cost_prev.
+      // if(data_i==9){
+      // 	printf("computing cost data_i=%d\n", data_i);
+      // 	verbose=1;
+      // }else{
+      // 	verbose=0;
+      // }
+      min_prev_cost.set_to_min_more_of(up_cost_prev, verbose);
+      status = min_prev_cost.check_min_of(up_cost_prev, up_cost_prev);
+      if(status){
+	printf("BAD MIN MORE CHECK data_i=%d status=%d\n", data_i, status);
+	printf("prev up cost\n");
+	up_cost_prev->print();
+	printf("min more(prev up cost)\n");
+	min_prev_cost.print();
+	throw status;
+      }
+      min_prev_cost.set_prev_seg_end(data_i-1);
+      //NO PENALTY FOR DOWN CHANGE
+      down_cost->set_to_min_env_of(&min_prev_cost, down_cost_prev, verbose);
+      status = down_cost->check_min_of(&min_prev_cost, down_cost_prev);
+      if(status){
+	printf("BAD MIN ENV CHECK data_i=%d status=%d\n", data_i, status);
+	printf("prev up cost\n");
+	up_cost_prev->print();
+	printf("min more(prev up cost)\n");
+	min_prev_cost.print();
+	printf("prev down cost\n");
+	down_cost_prev->print();
+	printf("new down cost model\n");
+	down_cost->print();
+	throw status;
+      }
+      down_cost->add
+	(weight_vec[data_i],
+	 -data_vec[data_i]*weight_vec[data_i],
+	 0.0);
+    }
+    up_cost_prev = up_cost;
+    down_cost_prev = down_cost;
+  }
+  // Decoding the cost_model_vec, and writing to the output matrices.
+  double best_cost, best_log_mean, candidate_cost, candidate_log_mean;
+  bool equality_constraint_active, candidate_constraint;
+  int prev_seg_end=data_count, candidate_end;
+  for(int i=0; i<data_count; i++){
+    mean_vec[i] = INFINITY;
+    end_vec[i] = -2;
+  }
+  for(int i=0; i<2*data_count; i++){
+    up_cost = &cost_model_mat[i];
+    intervals_mat[i] = up_cost->piece_list.size();
+    up_cost->Minimize
+      (cost_mat+i, &best_log_mean,
+       &prev_seg_end, &equality_constraint_active);
+  }
+  int prev_seg_offset = 0;
+  down_cost = &cost_model_mat[data_count*2-1];
+  down_cost->Minimize
+    (&best_cost, &best_log_mean,
+     &prev_seg_end, &equality_constraint_active);
+  mean_vec[0] = exp(best_log_mean);
+  end_vec[0] = prev_seg_end;
+  int out_i=1;
+  while(0 <= prev_seg_end){
+    //printf("decoding out_i=%d prev_seg_end=%d prev_seg_offset=%d\n", out_i, prev_seg_end, prev_seg_offset);
+    up_cost = &cost_model_mat[prev_seg_offset + prev_seg_end];
+    //up_cost->print();
+    if(equality_constraint_active){
+      up_cost->findMean
+	(best_log_mean, &prev_seg_end, &equality_constraint_active);
+    }else{
+      up_cost->Minimize
+	(&best_cost, &best_log_mean,
+	 &prev_seg_end, &equality_constraint_active);
+    }
+    if(prev_seg_offset==0){
+      prev_seg_offset = data_count;
+    }else{
+      prev_seg_offset = 0;
+    }
+    mean_vec[out_i] = exp(best_log_mean);
+    end_vec[out_i] = prev_seg_end;
+    out_i++;
+  }//for(data_i
+}
+
+void PeakSegFPOPall
+(int *data_vec, double *weight_vec, int data_count,
+ double penalty,
+ // the following matrices are for output.
+ // cost_mat and intervals_mat store the optimal cost and number of intervals
+ // at each time point, for the up and down cost models.
+ // end_vec and mean_vec store the best model up to and including the
+ // last data point. 
+ double *cost_mat, //data_count x 2.
+ int *end_vec, //data_count
+ double *mean_vec,//data_count
  int *intervals_mat,//data_count x 2
  int *label_vec){//data_count
   double min_log_mean=log(data_vec[0]), max_log_mean=log(data_vec[0]);
@@ -55,7 +224,7 @@ void PeakSegFPOPLog
 	 -data_vec[data_i]*weight_vec[data_i],
 	 0.0);
       // if data_i is down, it could have come from up_cost_prev.
-      min_prev_cost.set_to_min_more_of(up_cost_prev);
+      min_prev_cost.set_to_min_more_of(up_cost_prev, verbose);
       min_prev_cost.set_prev_seg_end(data_i-1);
       min_prev_cost.add(0.0, 0.0, penalty);
       down_cost->set_to_min_env_of(&min_prev_cost, down_cost_prev, verbose);

--- a/src/PeakSegFPOPLog.h
+++ b/src/PeakSegFPOPLog.h
@@ -5,5 +5,14 @@ void PeakSegFPOPLog
  double *cost_mat,
  int *end_vec,
  double *mean_vec,
+ int *intervals_mat);
+
+void PeakSegFPOPall
+(int *data_vec, double *weight_vec,
+ int data_count, double penalty,
+ // the following matrices are for output.
+ double *cost_mat,
+ int *end_vec,
+ double *mean_vec,
  int *intervals_mat,
   int *label_vec);

--- a/src/PeakSegPDPALog.cpp
+++ b/src/PeakSegPDPALog.cpp
@@ -5,7 +5,7 @@
 #include "funPieceListLog.h"
 #include <math.h>
 
-#define IFPRINT(arg) if(data_i==-490 && total_changes==-3) (arg)
+#define IFPRINT(arg) if(data_i==294 && total_changes==23) (arg)
 
 void PeakSegPDPALog
 (int *data_vec, double *weight_vec, int data_count,
@@ -45,7 +45,7 @@ void PeakSegPDPALog
       int prev_i = data_i-1;
       prev_cost_model = &cost_model_vec[prev_i + (total_changes-1)*data_count];
       IFPRINT(printf("DP changes=%d data_i=%d\n", total_changes, data_i));
-      IFPRINT(printf("prev cost model\n"));
+      IFPRINT(printf("=prev cost model\n"));
       IFPRINT(prev_cost_model->print());
       int verbose = 0;
       IFPRINT(verbose=1);
@@ -57,31 +57,31 @@ void PeakSegPDPALog
       min_prev_cost.set_prev_seg_end(prev_i);
       new_cost_model = &cost_model_vec[data_i + total_changes*data_count];
       if(data_i==total_changes){//first cost model, only one candidate.
-	IFPRINT(printf("new cost model = min prev cost\n"));
+	IFPRINT(printf("=new cost model = min prev cost\n"));
 	IFPRINT(min_prev_cost.print());
 	*new_cost_model = min_prev_cost;
       }else{
-	IFPRINT(printf("min prev cost\n"));
+	IFPRINT(printf("=min prev cost\n"));
         IFPRINT(min_prev_cost.print());
-	IFPRINT(printf("cost model\n"));
+	IFPRINT(printf("=cost model\n"));
 	IFPRINT(cost_model.print());
 	new_cost_model->set_to_min_env_of
 	  (&min_prev_cost, &cost_model, verbose);
 	int status = new_cost_model->check_min_of(&min_prev_cost, &cost_model);
 	if(status){
 	  printf("DP changes=%d data_i=%d BAD CHECK status=%d\n", total_changes, data_i, status);
-	  printf("prev cost model\n");
+	  printf("=prev cost model\n");
 	  prev_cost_model->print();
-	  printf("min prev cost\n");
+	  printf("=min prev cost\n");
 	  min_prev_cost.print();
-	  printf("cost model\n");
+	  printf("=cost model\n");
 	  cost_model.print();
-	  printf("new cost model\n");
+	  printf("=new cost model\n");
 	  new_cost_model->print();
 	  throw status;
 	}
       }
-      IFPRINT(printf("new cost model\n"));
+      IFPRINT(printf("=new cost model\n"));
       IFPRINT(new_cost_model->print());
       new_cost_model->add
 	(weight_vec[data_i],

--- a/src/PeakSegPDPALog.cpp
+++ b/src/PeakSegPDPALog.cpp
@@ -52,7 +52,7 @@ void PeakSegPDPALog
       if(total_changes % 2){
 	min_prev_cost.set_to_min_less_of(prev_cost_model, verbose);
       }else{
-	min_prev_cost.set_to_min_more_of(prev_cost_model);
+	min_prev_cost.set_to_min_more_of(prev_cost_model, verbose);
       }
       min_prev_cost.set_prev_seg_end(prev_i);
       new_cost_model = &cost_model_vec[data_i + total_changes*data_count];

--- a/src/PeakSegPDPALog.cpp
+++ b/src/PeakSegPDPALog.cpp
@@ -5,7 +5,7 @@
 #include "funPieceListLog.h"
 #include <math.h>
 
-#define IFPRINT(arg) if(data_i==293 && total_changes==10) (arg)
+#define IFPRINT(arg) if(data_i==370 && total_changes==-308) (arg)
 
 void PeakSegPDPALog
 (int *data_vec, double *weight_vec, int data_count,
@@ -92,10 +92,9 @@ void PeakSegPDPALog
     }
   }
 
-  double best_cost, best_log_mean;
+  double best_cost, best_log_mean, prev_log_mean;
   double *best_mean_vec;
   int *prev_seg_vec;
-  bool equality_constraint_active;
   int prev_seg_end;
   
   // Decoding the cost_model_vec, and writing to the output matrices.
@@ -115,9 +114,8 @@ void PeakSegPDPALog
       IFPRINT(cost_model->print());
       cost_model->Minimize
 	(&best_cost, &best_log_mean,
-	 &prev_seg_end, &equality_constraint_active,
-	 min_log_mean, max_log_mean);
-      IFPRINT(printf("cost=%f log_mean=%f prev_end=%d constraint=%d\n", best_cost, best_log_mean, prev_seg_end, equality_constraint_active));
+	 &prev_seg_end, &prev_log_mean);
+      IFPRINT(printf("cost=%f log_mean=%f prev_end=%d prev_log_mean=%f\n", best_cost, best_log_mean, prev_seg_end, prev_log_mean));
       // for the models up to any data point, we store the best cost
       // and the total number of intervals.
       cost_mat[data_i + total_changes*data_count] = best_cost;
@@ -134,25 +132,12 @@ void PeakSegPDPALog
 	for(int seg_i=total_changes-1; 0 <= seg_i; seg_i--){
 	  //printf("seg_i=%d prev_seg_end=%d\n", seg_i, prev_seg_end);
 	  cost_model = &cost_model_vec[prev_seg_end + seg_i*data_count];
-	  if(equality_constraint_active){
-	    cost_model->findMean
-	      (best_log_mean, &prev_seg_end, &equality_constraint_active);
-	  }else{
-	    double this_min, this_max;
-	    if(seg_i % 2){
-	      // 1, 3, 5, ... up segment, lower bound.
-	      this_min = best_log_mean;
-	      this_max = max_log_mean;
-	    }else{
-	      // 0, 2, 4, ... down segment, upper bound.
-	      this_min = min_log_mean;
-	      this_max = best_log_mean;
-	    }
-	    cost_model->Minimize
-	      (&best_cost, &best_log_mean,
-	       &prev_seg_end, &equality_constraint_active,
-	       this_min, this_max);
+	  if(prev_log_mean != INFINITY){
+	    //equality constraint inactive
+	    best_log_mean = prev_log_mean;
 	  }
+	  cost_model->findMean
+	    (best_log_mean, &prev_seg_end, &prev_log_mean);
 	  best_mean_vec[seg_i] = exp(best_log_mean);
 	  prev_seg_vec[seg_i] = prev_seg_end;
 	}//for(seg_i

--- a/src/funPieceListLog.cpp
+++ b/src/funPieceListLog.cpp
@@ -513,10 +513,14 @@ void PoissonLossPieceLog::print(){
 	 min_log_mean, max_log_mean, data_i);
 }
 
-void PiecewisePoissonLossLog::Minimize(double *best_cost,
-	      double *best_log_mean,
-	      int *data_i,
-	      bool *equality_constraint_active){
+void PiecewisePoissonLossLog::Minimize
+(double *best_cost,
+ double *best_log_mean,
+ int *data_i,
+ bool *equality_constraint_active,
+ double min_log_mean,
+ double max_log_mean
+ ){
   double candidate_cost, candidate_log_mean;
   int verbose=false;
   PoissonLossPieceListLog::iterator it;
@@ -524,7 +528,9 @@ void PiecewisePoissonLossLog::Minimize(double *best_cost,
   for(it=piece_list.begin(); it != piece_list.end(); it++){
     candidate_log_mean = it->argmin();
     if(it->min_log_mean <= candidate_log_mean &&
-       candidate_log_mean <= it->max_log_mean){
+       candidate_log_mean <= it->max_log_mean &&
+       min_log_mean <= candidate_log_mean &&
+       candidate_log_mean <= max_log_mean){
       candidate_cost = it->getCost(candidate_log_mean);
       if(candidate_cost < *best_cost){
 	*best_cost = candidate_cost;

--- a/src/funPieceListLog.h
+++ b/src/funPieceListLog.h
@@ -37,7 +37,7 @@ class PiecewisePoissonLossLog {
  public:
   PoissonLossPieceListLog piece_list;
   void set_to_min_less_of(PiecewisePoissonLossLog *, int);
-  void set_to_min_more_of(PiecewisePoissonLossLog *);
+  void set_to_min_more_of(PiecewisePoissonLossLog *, int);
   void set_to_min_env_of
     (PiecewisePoissonLossLog *, PiecewisePoissonLossLog *, int);
   int check_min_of(PiecewisePoissonLossLog *, PiecewisePoissonLossLog *);

--- a/src/funPieceListLog.h
+++ b/src/funPieceListLog.h
@@ -16,9 +16,10 @@ class PoissonLossPieceLog {
   double min_log_mean;
   double max_log_mean;
   int data_i;
-  bool equality_constraint_active;
+  double prev_log_mean;
+  bool equality_constraint_active();
   PoissonLossPieceLog
-    (double li, double lo, double co, double m, double M, int i, bool a);
+    (double li, double lo, double co, double m, double M, int i, double);
   double argmin();
   double argmin_mean();
   void print();
@@ -48,14 +49,13 @@ class PiecewisePoissonLossLog {
   void add(double Linear, double Log, double Constant);
   void print();
   void set_prev_seg_end(int prev_seg_end);
-  void findMean(double mean, int *seg_end, bool *equality_constraint_active);
+  void findMean(double mean, int *seg_end, double *prev_log_mean);
   double findCost(double mean);
   void Minimize
     (double *best_cost,
      double *best_mean,
      int *data_i,
-     bool *equality_constraint_active,
-     double, double);
+     double *prev_log_mean);
 };
 
 bool sameFuns(PoissonLossPieceListLog::iterator, PoissonLossPieceListLog::iterator);

--- a/src/funPieceListLog.h
+++ b/src/funPieceListLog.h
@@ -50,10 +50,12 @@ class PiecewisePoissonLossLog {
   void set_prev_seg_end(int prev_seg_end);
   void findMean(double mean, int *seg_end, bool *equality_constraint_active);
   double findCost(double mean);
-  void Minimize(double *best_cost,
-		double *best_mean,
-		int *data_i,
-		bool *equality_constraint_active);
+  void Minimize
+    (double *best_cost,
+     double *best_mean,
+     int *data_i,
+     bool *equality_constraint_active,
+     double, double);
 };
 
 bool sameFuns(PoissonLossPieceListLog::iterator, PoissonLossPieceListLog::iterator);

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -19,13 +19,10 @@ extern "C" {
   (int *data_ptr, double *weight_ptr,
    int *data_count, double *penalty,
    double *cost_mat, int *end_vec,
-   double *mean_vec, int *intervals_mat,
-   int *label_vec
-   ){
+   double *mean_vec, int *intervals_mat){
     PeakSegFPOPLog(data_ptr, weight_ptr,
 		   *data_count, *penalty,
-		   cost_mat, end_vec, mean_vec, intervals_mat,
-		   label_vec);
+		   cost_mat, end_vec, mean_vec, intervals_mat);
   }
   
 }

--- a/tests/testthat/plot.R
+++ b/tests/testthat/plot.R
@@ -1,0 +1,67 @@
+subject <- "
+=prev up cost
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+         8         -6 229.114503       -inf   0.000000 7
+         2          0 235.114503   0.000000   0.595818 7
+        66       -122 191.675361   0.595818   0.693661 5
+         2          0 235.114503   0.693661   3.496508 7
+=min more(prev up cost)
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+         0          0 238.722672       -inf   0.614366 5
+        66       -122 191.675361   0.614366   0.693661 5
+         2          0 235.114503   0.693661   3.496508 7
+"
+pattern <- paste0(
+  "=(?<fun>.*?)\n",
+  "(?<table>",
+  "(?:[^=].*?\n)*",
+  ")")
+library(namedCapture)
+(mat <- str_match_all_named(subject, pattern)[[1]])
+funs.list <- list()
+library(data.table)
+ploss <- function(dt, x){
+  ## need to make a new data table, otherwise ifelse may only get one
+  ## element, and return only one element.
+  new.dt <- data.table(dt, x)
+  new.dt[, ifelse(Log==0, 0, Log*log(x)) + Linear*x + Constant]
+}
+getLines <- function(dt){
+  line.list <- list()
+  for(piece.i in 1:nrow(dt)){
+    piece <- dt[piece.i,]
+    mean.vec <- piece[, seq(exp(min_log_mean), exp(max_log_mean), l=100)]
+    line.list[[piece.i]] <- data.table(
+      piece.i,
+      piece,
+      mean=mean.vec,
+      log.mean=log(mean.vec),
+      cost=ploss(piece, mean.vec))
+  }
+  do.call(rbind, line.list)
+}
+vlines.list <- list()
+for(row.i in 1:nrow(mat)){
+  r <- mat[row.i,]
+  df <- read.table(text=r[["table"]], header=TRUE)
+  dt <- data.table(df)
+  l <- getLines(dt)
+  fun <- r[["fun"]]
+  funs.list[[row.i]] <- data.table(fun, l)
+  vlines.list[[row.i]] <- data.table(fun, dt[-1,])
+}
+funs <- do.call(rbind, funs.list)
+vlines <- do.call(rbind, vlines.list)
+library(ggplot2)
+ggplot()+
+  geom_vline(aes(xintercept=min_log_mean, color=fun), data=vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=funs)
+
+ggplot()+
+  geom_vline(aes(xintercept=min_log_mean, color=fun), data=vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=funs)+
+  coord_cartesian(xlim=c(0.5,0.75), ylim=c(238, 240))

--- a/tests/testthat/plot.R
+++ b/tests/testthat/plot.R
@@ -1,29 +1,11 @@
-subject <- "
-=prev cost model
-    Linear        Log   Constant min_log_mean max_log_mean     data_i
-        40          0 -20724.638304       -inf  -1.867945 292
-        57        -17 -20759.018862  -1.867945   0.100106 291
-       105       -113 -20802.462502   0.100106   0.249963 290
-       189       -298 -20864.073454   0.249963   0.456140 286
-       208       -345 -20872.616321   0.456140   0.869969 284
-       226       -399 -20868.601058   0.869969   0.926387 283
-       667      -1793 -20690.905073   0.926387   1.136442 257
-       887      -2830 -20197.860455   1.136442   1.397192 236
-       888      -2841 -20186.535169   1.397192   1.443866 235
-        57        -17 -20743.028552   1.443866   3.496508 292
-=min prev cost
-    Linear        Log   Constant min_log_mean max_log_mean     data_i
-         0          0 -20724.638304       -inf   3.496508 293
-"
 pattern <- paste0(
   "=(?<fun>.*?)\n",
   "(?<table>",
   "(?:[^=].*?\n)*",
   ")")
 library(namedCapture)
-(mat <- str_match_all_named(subject, pattern)[[1]])
-funs.list <- list()
 library(data.table)
+library(ggplot2)
 ploss <- function(dt, x){
   ## need to make a new data table, otherwise ifelse may only get one
   ## element, and return only one element.
@@ -44,21 +26,158 @@ getLines <- function(dt){
   }
   do.call(rbind, line.list)
 }
-vlines.list <- list()
-for(row.i in 1:nrow(mat)){
-  r <- mat[row.i,]
-  df <- read.table(text=r[["table"]], header=TRUE)
-  dt <- data.table(df)
-  l <- getLines(dt)
-  fun <- r[["fun"]]
-  funs.list[[row.i]] <- data.table(fun, l)
-  if(1 < nrow(dt)){
-    vlines.list[[row.i]] <- data.table(fun, dt[-1,])
+gdata <- function(txt){
+  mat <- str_match_all_named(txt, pattern)[[1]]
+  funs.list <- list()
+  vlines.list <- list()
+  for(row.i in 1:nrow(mat)){
+    r <- mat[row.i,]
+    df <- read.table(text=r[["table"]], header=TRUE)
+    dt <- data.table(df)
+    l <- getLines(dt)
+    fun <- r[["fun"]]
+    funs.list[[row.i]] <- data.table(fun, l)
+    if(1 < nrow(dt)){
+      vlines.list[[row.i]] <- data.table(fun, dt[-1,])
+    }
   }
+  list(
+    funs=do.call(rbind, funs.list),
+    vlines=do.call(rbind, vlines.list))
 }
-funs <- do.call(rbind, funs.list)
-vlines <- do.call(rbind, vlines.list)
-library(ggplot2)
+
+C11.301minless <- gdata("
+=prev cost model
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+        22          0 -19706.460691       -inf  -1.917963 299
+        71        -49 -19807.639270  -1.917963   0.370000 298
+       402       -797 -20010.079492   0.370000   0.445068 286
+       421       -844 -20018.812620   0.445068   0.850674 284
+       439       -898 -20015.018261   0.850674   0.865637 283
+      1097      -3300 -19499.507878   0.865637   1.127393 238
+      1098      -3309 -19492.448939   1.127393   1.414200 237
+      1100      -3329 -19472.391333   1.414200   1.482339 236
+        71        -49 -19803.536430   1.482339   3.496508 299
+=min prev cost
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+         0          0 -19706.460691       -inf  -1.833168 300
+        71        -49 -19807.639270  -1.833168  -0.370860 300
+         0          0 -19740.467150  -0.370860   0.461754 300
+       421       -844 -20018.812620   0.461754   0.695520 300
+         0          0 -19761.831214   0.695520   0.884747 300
+      1097      -3300 -19499.507878   0.884747   1.101343 300
+         0          0 -19833.940726   1.101343   3.496508 300
+")
+ggplot()+
+  geom_vline(xintercept=log(2.85))+
+  geom_vline(xintercept=0.656780)+
+  coord_cartesian(xlim=c(0,2), ylim=c(-20000, -19500))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C11.301minless$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=C11.301minless$funs)
+
+C11.301minenv <- gdata("
+=min prev cost
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+         0          0 -19706.460691       -inf  -1.833168 300
+        71        -49 -19807.639270  -1.833168  -0.370860 300
+         0          0 -19740.467150  -0.370860   0.461754 300
+       421       -844 -20018.812620   0.461754   0.695520 300
+         0          0 -19761.831214   0.695520   0.884747 300
+      1097      -3300 -19499.507878   0.884747   1.101343 300
+         0          0 -19833.940726   1.101343   3.496508 300
+=cost model
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+        71        -49 -19807.639270       -inf   0.000000 299
+        22          0 -19758.639270   0.000000   0.309734 299
+       213       -499 -19864.426823   0.309734   0.930885 293
+      1097      -3300 -19499.507878   0.930885   1.121603 299
+        22          0 -19900.793841   1.121603   3.496508 299
+=new cost model
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+         0          0 -19706.460691       -inf  -1.833168 300
+        71        -49 -19807.639270  -1.833168  -0.370860 300
+         0          0 -19740.467150  -0.370860   0.368836 300
+       213       -499 -19864.426823   0.368836   0.930885 293
+      1097      -3300 -19499.507878   0.930885   1.101343 300
+         0          0 -19833.940726   1.101343   3.496508 300
+")
+ggplot()+
+  geom_vline(xintercept=log(2.85))+
+  geom_vline(xintercept=0.656780)+
+  coord_cartesian(xlim=c(0,2), ylim=c(-20000, -19500))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C11.301minenv$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=C11.301minenv$funs)
+## The min comes from (should not be here)
+##        213       -499 -19864.426823   0.368836   0.930885 293
+
+C11.301 <- gdata("
+=new cost model
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+        95        -95 -19706.460691       -inf  -1.833168 300
+       166       -144 -19807.639270  -1.833168  -0.370860 300
+        95        -95 -19740.467150  -0.370860   0.368836 300
+       308       -594 -19864.426823   0.368836   0.930885 293
+      1192      -3395 -19499.507878   0.930885   1.101343 300
+        95        -95 -19833.940726   1.101343   3.496508 300
+")
+ggplot()+
+  geom_vline(xintercept=log(2.85))+
+  coord_cartesian(xlim=c(-1,2), ylim=c(-19700, -19600))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C11.301$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=C11.301$funs)+
+  geom_point(aes(x=0.656780, y=-19660.553868))
+
+## prev cost model is C10.293.
+C11.294minless <- gdata("
+=prev cost model
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+        40          0 -19864.426823       -inf  -2.005918 292
+        57        -17 -19900.814557  -2.005918   0.042381 291
+       105       -113 -19946.823999   0.042381   0.228953 290
+       189       -298 -20010.079492   0.228953   0.445068 286
+       208       -345 -20018.812620   0.445068   0.850674 284
+       226       -399 -20015.018261   0.850674   0.865637 283
+       884      -2801 -19499.507878   0.865637   1.127393 238
+       885      -2810 -19492.448939   1.127393   1.414200 237
+       887      -2830 -19472.391333   1.414200   1.568696 236
+        57        -17 -19900.814557   1.568696   3.496508 292
+=min prev cost
+    Linear        Log   Constant min_log_mean max_log_mean     data_i
+         0          0 -19864.426823       -inf   0.930885 293
+       884      -2801 -19499.507878   0.930885   1.127393 293
+       885      -2810 -19492.448939   1.127393   1.155352 293
+         0          0 -19928.988388   1.155352   3.496508 293
+")
+ggplot()+
+  geom_vline(xintercept=0.656780)+
+  geom_vline(xintercept=log(2.85))+
+  coord_cartesian(ylim=c(-20000, -19800))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C11.294minless$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=C11.294minless$funs)
+## Is there a problem with creating a constant segment on the left?
+
+ggplot()+
+  geom_vline(xintercept=0.656780)+
+  geom_vline(xintercept=log(2.85))+
+  coord_cartesian(xlim=c(0,2), ylim=c(-20000, -19500))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C11.294minless$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
+            size=2,
+            data=C11.294minless$funs)
+
 ggplot()+
   geom_vline(aes(xintercept=exp(min_log_mean), color=fun), data=vlines)+
   geom_line(aes(mean, cost, color=fun),
@@ -71,3 +190,4 @@ ggplot()+
   geom_line(aes(mean, cost, color=fun),
             size=2,
             data=funs)
+

--- a/tests/testthat/plot.R
+++ b/tests/testthat/plot.R
@@ -1,15 +1,19 @@
 subject <- "
-=prev up cost
+=prev cost model
     Linear        Log   Constant min_log_mean max_log_mean     data_i
-         8         -6 229.114503       -inf   0.000000 7
-         2          0 235.114503   0.000000   0.595818 7
-        66       -122 191.675361   0.595818   0.693661 5
-         2          0 235.114503   0.693661   3.496508 7
-=min more(prev up cost)
+        40          0 -20724.638304       -inf  -1.867945 292
+        57        -17 -20759.018862  -1.867945   0.100106 291
+       105       -113 -20802.462502   0.100106   0.249963 290
+       189       -298 -20864.073454   0.249963   0.456140 286
+       208       -345 -20872.616321   0.456140   0.869969 284
+       226       -399 -20868.601058   0.869969   0.926387 283
+       667      -1793 -20690.905073   0.926387   1.136442 257
+       887      -2830 -20197.860455   1.136442   1.397192 236
+       888      -2841 -20186.535169   1.397192   1.443866 235
+        57        -17 -20743.028552   1.443866   3.496508 292
+=min prev cost
     Linear        Log   Constant min_log_mean max_log_mean     data_i
-         0          0 238.722672       -inf   0.614366 5
-        66       -122 191.675361   0.614366   0.693661 5
-         2          0 235.114503   0.693661   3.496508 7
+         0          0 -20724.638304       -inf   3.496508 293
 "
 pattern <- paste0(
   "=(?<fun>.*?)\n",
@@ -48,20 +52,22 @@ for(row.i in 1:nrow(mat)){
   l <- getLines(dt)
   fun <- r[["fun"]]
   funs.list[[row.i]] <- data.table(fun, l)
-  vlines.list[[row.i]] <- data.table(fun, dt[-1,])
+  if(1 < nrow(dt)){
+    vlines.list[[row.i]] <- data.table(fun, dt[-1,])
+  }
 }
 funs <- do.call(rbind, funs.list)
 vlines <- do.call(rbind, vlines.list)
 library(ggplot2)
 ggplot()+
-  geom_vline(aes(xintercept=min_log_mean, color=fun), data=vlines)+
-  geom_line(aes(log.mean, cost, color=fun),
+  geom_vline(aes(xintercept=exp(min_log_mean), color=fun), data=vlines)+
+  geom_line(aes(mean, cost, color=fun),
             size=2,
             data=funs)
 
 ggplot()+
-  geom_vline(aes(xintercept=min_log_mean, color=fun), data=vlines)+
-  geom_line(aes(log.mean, cost, color=fun),
+  geom_vline(aes(xintercept=exp(min_log_mean), color=fun), data=vlines)+
+  coord_cartesian(ylim=c(-21000, -20500), xlim=c(0, 3))+
+  geom_line(aes(mean, cost, color=fun),
             size=2,
-            data=funs)+
-  coord_cartesian(xlim=c(0.5,0.75), ylim=c(238, 240))
+            data=funs)

--- a/tests/testthat/plot.R
+++ b/tests/testthat/plot.R
@@ -168,26 +168,63 @@ ggplot()+
             data=C11.294minless$funs)
 ## Is there a problem with creating a constant segment on the left?
 
+C153.370minless <- gdata("
+=prev cost model
+    Linear        Log        Constant    min_log_mean    max_log_mean   prev_log_mean data_i
+         5         -9   -20936.673374            -inf        0.000000             inf 368
+        54        -58   -20985.673374        0.000000        0.072759             inf 368
+         1         -1   -20932.820658        0.072759        3.496508        0.072759 368
+=min prev cost
+    Linear        Log        Constant    min_log_mean    max_log_mean   prev_log_mean data_i
+         0          0   -20931.817994            -inf        0.071459        0.071459 369
+        54        -58   -20985.673374        0.071459        0.072759             inf 369
+         1         -1   -20932.820658        0.072759        3.496508             inf 369
+")
 ggplot()+
-  geom_vline(xintercept=0.656780)+
-  geom_vline(xintercept=log(2.85))+
-  coord_cartesian(xlim=c(0,2), ylim=c(-20000, -19500))+
   geom_vline(aes(xintercept=min_log_mean, color=fun),
-             data=C11.294minless$vlines)+
+             data=C153.370minless$vlines)+
   geom_line(aes(log.mean, cost, color=fun),
             size=2,
-            data=C11.294minless$funs)
+            data=C153.370minless$funs)
 
+C153.370minenv <- gdata("
+=min prev cost
+    Linear        Log        Constant    min_log_mean    max_log_mean   prev_log_mean data_i
+         0          0   -20931.817994            -inf        0.071459        0.071459 369
+        54        -58   -20985.673374        0.071459        0.072759             inf 369
+         1         -1   -20932.820658        0.072759        3.496508             inf 369
+=cost model
+    Linear        Log        Constant    min_log_mean    max_log_mean   prev_log_mean data_i
+         1         -1   -20932.820658            -inf        0.072759        0.072759 368
+        54        -58   -20985.673374        0.072759        0.438176             inf 368
+         1         -1   -20928.505894        0.438176        0.693147        0.693147 368
+         5         -9   -20930.960717        0.693147        3.496508             inf 368
+=new cost model
+    Linear        Log        Constant    min_log_mean    max_log_mean   prev_log_mean data_i
+         0          0   -20931.817994            -inf       -0.073882        0.071459 369
+         1         -1   -20932.820658       -0.073882        3.496508        0.072759 368
+")
 ggplot()+
-  geom_vline(aes(xintercept=exp(min_log_mean), color=fun), data=vlines)+
-  geom_line(aes(mean, cost, color=fun),
+  ##coord_cartesian(xlim=c(-1, 1), ylim=c(-20900, -20897.5))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C153.370minenv$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
             size=2,
-            data=funs)
+            data=C153.370minenv$funs)
 
+
+C153.370 <- gdata("
+=new cost model
+    Linear        Log        Constant    min_log_mean    max_log_mean   prev_log_mean data_i
+         5         -9   -20899.328801            -inf       -0.188525             inf 369
+        58        -66   -20953.968258       -0.188525        0.309648            -inf 366
+         4         -8   -20898.328801        0.309648        3.496508        0.000000 369
+")
 ggplot()+
-  geom_vline(aes(xintercept=exp(min_log_mean), color=fun), data=vlines)+
-  coord_cartesian(ylim=c(-21000, -20500), xlim=c(0, 3))+
-  geom_line(aes(mean, cost, color=fun),
+  ##coord_cartesian(xlim=c(-1, 1), ylim=c(-20900, -20897.5))+
+  geom_vline(aes(xintercept=min_log_mean, color=fun),
+             data=C153.370$vlines)+
+  geom_line(aes(log.mean, cost, color=fun),
             size=2,
-            data=funs)
+            data=C153.370$funs)
 

--- a/tests/testthat/test-PeakSegFPOP.R
+++ b/tests/testthat/test-PeakSegFPOP.R
@@ -3,8 +3,9 @@ data.vec <- as.integer(c(1, 10, 14, 13))
 fit <- PeakSegFPOP(data.vec, rep(1L, 4), 0)
 library(testthat)
 test_that("no penalty is OK", {
-  best.cost <- min(fit$cost.mat[,4])
-  exp.cost <- PoissonLoss(data.vec, rev(fit$mean.vec))
+  best.cost <- min(fit$cost.mat[2,4])
+  mean.vec <- c(1, rep(37/3, 3))
+  exp.cost <- PoissonLoss(data.vec, mean.vec)
   expect_equal(best.cost, exp.cost)
 })
 
@@ -35,9 +36,17 @@ by.sample <- split(
 test_that("FPOP recovers the same models as PDPA", {
   one.name <- "McGill0004"
   one <- by.sample[[one.name]]
-  pdpa <- PeakSegPDPAchrom(one, 9L)
+  max.peaks <- as.integer((nrow(one)-1)/2)
+  pdpa <- PeakSegPDPAchrom(one, max.peaks)
+  dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
+  some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
   segs.by.peaks <- split(pdpa$segments, pdpa$segments$peaks)
-  some.models <- pdpa$modelSelection[-1,]
+  for(peaks.str in names(segs.by.peaks)){
+    pdpa.segs <- segs.by.peaks[[peaks.str]]
+    sign.diff <- sign(diff(pdpa.segs$mean))*c(1,-1)
+    right.sign <- sign.diff %in% c(0, 1)
+    expect_true(all(right.sign))
+  }
   for(model.i in 1:nrow(some.models)){
     model.row <- some.models[model.i,]
     lambda <- with(model.row, if(max.lambda==Inf){
@@ -49,5 +58,8 @@ test_that("FPOP recovers the same models as PDPA", {
     rownames(exp.segs) <- NULL
     fpop <- PeakSegFPOPchrom(one, lambda)
     expect_equal(fpop$segments, exp.segs)
+    if(nrow(fpop$segments) != nrow(exp.segs)){
+      print(model.row)
+    }
   }
 })

--- a/tests/testthat/test-PeakSegFPOP.R
+++ b/tests/testthat/test-PeakSegFPOP.R
@@ -42,15 +42,16 @@ test_that("FPOP recovers the same models as PDPA", {
   }
   max.peaks <- as.integer((nrow(one)-1)/2)
   pdpa <- PeakSegPDPAchrom(one, max.peaks)
-  dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
-  some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
   segs.by.peaks <- split(pdpa$segments, pdpa$segments$peaks)
   for(peaks.str in names(segs.by.peaks)){
     pdpa.segs <- segs.by.peaks[[peaks.str]]
+    rownames(pdpa.segs) <- NULL
     sign.diff <- sign(diff(pdpa.segs$mean))*c(1,-1)
     right.sign <- sign.diff %in% c(0, 1)
     expect_true(all(right.sign))
   }
+  dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
+  some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
   for(model.i in 1:nrow(some.models)){
     model.row <- some.models[model.i,]
     lambda <- with(model.row, if(max.lambda==Inf){
@@ -61,9 +62,9 @@ test_that("FPOP recovers the same models as PDPA", {
     exp.segs <- segs.by.peaks[[paste(model.row$peaks)]]
     rownames(exp.segs) <- NULL
     fpop <- PeakSegFPOPchrom(one, lambda)
-    ##expect_equal(fpop$segments, exp.segs)
     if(nrow(fpop$segments) != nrow(exp.segs)){
       print(model.row)
     }
+    expect_equal(fpop$segments, exp.segs)
   }
 })

--- a/tests/testthat/test-PeakSegFPOP.R
+++ b/tests/testthat/test-PeakSegFPOP.R
@@ -41,10 +41,6 @@ test_that("FPOP recovers the same models as PDPA", {
     with(df, sum(bases*count)/sum(bases))
   }
   max.peaks <- as.integer((nrow(one)-1)/2)
-  one <- one[1:301,] # bug when 302.
-  max.segs <- 12L
-  fit <- with(one, PeakSegPDPA(count, bases, max.segs))
-  fit$mean.mat
   pdpa <- PeakSegPDPAchrom(one, max.peaks)
   dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
   some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
@@ -65,7 +61,7 @@ test_that("FPOP recovers the same models as PDPA", {
     exp.segs <- segs.by.peaks[[paste(model.row$peaks)]]
     rownames(exp.segs) <- NULL
     fpop <- PeakSegFPOPchrom(one, lambda)
-    expect_equal(fpop$segments, exp.segs)
+    ##expect_equal(fpop$segments, exp.segs)
     if(nrow(fpop$segments) != nrow(exp.segs)){
       print(model.row)
     }

--- a/tests/testthat/test-PeakSegFPOP.R
+++ b/tests/testthat/test-PeakSegFPOP.R
@@ -36,7 +36,15 @@ by.sample <- split(
 test_that("FPOP recovers the same models as PDPA", {
   one.name <- "McGill0004"
   one <- by.sample[[one.name]]
+  one$bases <- with(one, chromEnd-chromStart)
+  wmean <- function(df){
+    with(df, sum(bases*count)/sum(bases))
+  }
   max.peaks <- as.integer((nrow(one)-1)/2)
+  one <- one[1:301,] # bug when 302.
+  max.segs <- 12L
+  fit <- with(one, PeakSegPDPA(count, bases, max.segs))
+  fit$mean.mat
   pdpa <- PeakSegPDPAchrom(one, max.peaks)
   dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
   some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))

--- a/tests/testthat/test-PeakSegFPOP.R
+++ b/tests/testthat/test-PeakSegFPOP.R
@@ -33,16 +33,16 @@ H3K4me3_XJ_immune_chunk1$count <- H3K4me3_XJ_immune_chunk1$coverage
 by.sample <- split(
   H3K4me3_XJ_immune_chunk1, H3K4me3_XJ_immune_chunk1$sample.id)
 
-test_that("FPOP recovers the same models as PDPA", {
-  one.name <- "McGill0004"
-  one <- by.sample[[one.name]]
-  one$bases <- with(one, chromEnd-chromStart)
-  wmean <- function(df){
-    with(df, sum(bases*count)/sum(bases))
-  }
-  max.peaks <- as.integer((nrow(one)-1)/2)
-  pdpa <- PeakSegPDPAchrom(one, max.peaks)
-  segs.by.peaks <- split(pdpa$segments, pdpa$segments$peaks)
+one.name <- "McGill0004"
+one <- by.sample[[one.name]]
+one$bases <- with(one, chromEnd-chromStart)
+wmean <- function(df){
+  with(df, sum(bases*count)/sum(bases))
+}
+max.peaks <- as.integer((nrow(one)-1)/2)
+pdpa <- PeakSegPDPAchrom(one, max.peaks)
+segs.by.peaks <- split(pdpa$segments, pdpa$segments$peaks)
+test_that("PDPA segment means are feasible", {
   for(peaks.str in names(segs.by.peaks)){
     pdpa.segs <- segs.by.peaks[[peaks.str]]
     rownames(pdpa.segs) <- NULL
@@ -50,8 +50,11 @@ test_that("FPOP recovers the same models as PDPA", {
     right.sign <- sign.diff %in% c(0, 1)
     expect_true(all(right.sign))
   }
-  dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
-  some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
+})
+
+dec.loss <- subset(pdpa$loss, c(TRUE, diff(PoissonLoss) < 0))
+some.models <- with(dec.loss, exactModelSelection(PoissonLoss, peaks, peaks))
+test_that("FPOP recovers the same models as PDPA", {
   for(model.i in 1:nrow(some.models)){
     model.row <- some.models[model.i,]
     lambda <- with(model.row, if(max.lambda==Inf){


### PR DESCRIPTION
there seems to be a bug in a min-more or min-less computation?

in the test, with `peaks.str <- "11"` the current code recovers the following segment means

```
> pdpa.segs
          mean first last chromStart chromEnd     status peaks segments
  0  0.5704225     1    4   20006254 20006680 background    11       23
  1  2.7558140     5   23   20006680 20007024       peak    11       23
  2  0.0000000    24   24   20007024 20007247 background    11       23
  3  2.2068966    25   40   20007247 20007624       peak    11       23
  4  1.1056180    41   51   20007624 20008069 background    11       23
  5  8.4318182    52   99   20008069 20008377       peak    11       23
  6  0.2507937   100  103   20008377 20008692 background    11       23
  7  4.5454545   104  109   20008692 20008729       peak    11       23
  8  4.5454545   110  110   20008729 20008736 background    11       23
  9 19.8344519   111  238   20008736 20009183       peak    11       23
 10  3.1751412   239  294   20009183 20010068 background    11       23
 11  2.1007828   295  334   20010068 20011090       peak    11       23 
 12  0.0000000   335  335   20011090 20011302 background    11       23
 13  2.2891304   336  356   20011302 20011762       peak    11       23
 14  0.0000000   357  357   20011762 20011875 background    11       23
 15  1.5683710   358  382   20011875 20012716       peak    11       23
 16  0.0000000   383  383   20012716 20013008 background    11       23
 17  1.8039216   384  386   20013008 20013110       peak    11       23
 18  0.0000000   387  387   20013110 20013410 background    11       23
 19  2.6164384   388  391   20013410 20013556       peak    11       23
 20  0.0000000   392  392   20013556 20013729 background    11       23
 21  2.2273361   393  425   20013729 20014446       peak    11       23
 22  0.1090909   426  427   20014446 20014776 background    11       23
>
```

equality constraint is fine but then there are two changes down, which does not make sense.
