### PR TITLE
add unconstrained Poisson FPOP and isotonic Normal FPOP solvers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,5 +21,6 @@ Imports: penaltyLearning
 Suggests: 
  PeakSegDP (>= 2016.08.06),
  cosegData,
+ fpop,
  ggplot2, testthat, data.table (>= 1.9.8)
 Remotes: tdhock/cosegData

--- a/R/NormalFPOPisotonic.R
+++ b/R/NormalFPOPisotonic.R
@@ -1,0 +1,33 @@
+NormalFPOPisotonic <- function
+(data.vec,
+ penalty=NULL
+){
+  n.data <- length(data.vec)
+  stopifnot(2 <= n.data)
+  stopifnot(is.numeric(data.vec))
+  stopifnot(is.numeric(penalty))
+  stopifnot(length(penalty) == 1)
+  stopifnot(0 <= penalty)
+  cost.vec <- double(n.data)
+  end.vec <- integer(n.data)
+  mean.vec <- double(n.data)
+  intervals.vec <- integer(n.data)
+  result.list <- .C(
+    "NormalFPOPisotonic_interface",
+    data.vec=as.double(data.vec),
+    n.data=as.integer(n.data),
+    penalty=as.numeric(penalty),
+    cost.vec=as.double(cost.vec),
+    end.vec=as.integer(end.vec),
+    mean.vec=as.double(mean.vec),
+    intervals.vec=as.integer(intervals.vec),
+    PACKAGE="PeakSegOptimal")
+  n.segments <- sum(result.list$end.vec != -2L)
+  if(n.segments == 0) n.segments <- 1L
+  seg.mean <- rev(result.list$mean.vec[1:n.segments])
+  seg.end <- rev(result.list$end.vec[1:n.segments])
+  result.list$seg.mean <- seg.mean
+  result.list$seg.end <- seg.end + 1L
+  result.list$n.segments <- n.segments
+  result.list
+}

--- a/R/NormalFPOPisotonic.R
+++ b/R/NormalFPOPisotonic.R
@@ -1,6 +1,11 @@
-NormalFPOPisotonic <- function
+NormalFPOPisotonic <- structure(function
+### Regularized isotonic regression using the Normal (squared-error)
+### loss. With penalty=0 this gives the same result as isoreg (PAVA).
 (data.vec,
+### numeric vector of data to segment.
  penalty=NULL
+### non-negative numeric scalar: penalty for each changepoint.
+### Use penalty=0 for unpenalized isotonic regression.
 ){
   n.data <- length(data.vec)
   stopifnot(2 <= n.data)
@@ -30,4 +35,7 @@ NormalFPOPisotonic <- function
   result.list$seg.end <- seg.end + 1L
   result.list$n.segments <- n.segments
   result.list
-}
+### List with seg.mean (chronological, non-decreasing segment means),
+### seg.end (1-indexed segment ends), n.segments, cost.vec, end.vec,
+### mean.vec, intervals.vec.
+})

--- a/R/PoissonFPOPunconstrained.R
+++ b/R/PoissonFPOPunconstrained.R
@@ -1,7 +1,13 @@
-PoissonFPOPunconstrained <- function
+PoissonFPOPunconstrained <- structure(function
+### Unconstrained optimal changepoint detection using the Poisson loss
+### and the FPOP algorithm. Unlike PeakSegFPOP, there is no up-down
+### constraint on segment means.
 (count.vec,
+### integer vector of non-negative count data to segment.
  weight.vec=rep(1, length(count.vec)),
+### numeric vector (same length as count.vec) of positive weights.
  penalty=NULL
+### non-negative numeric scalar: penalty for each changepoint.
 ){
   n.data <- length(count.vec)
   stopifnot(2 <= n.data)
@@ -36,4 +42,7 @@ PoissonFPOPunconstrained <- function
   result.list$seg.end <- seg.end + 1L
   result.list$n.segments <- n.segments
   result.list
-}
+### List with seg.mean (chronological segment means), seg.end
+### (1-indexed segment ends), n.segments, cost.vec, end.vec,
+### mean.vec, intervals.vec.
+})

--- a/R/PoissonFPOPunconstrained.R
+++ b/R/PoissonFPOPunconstrained.R
@@ -1,0 +1,39 @@
+PoissonFPOPunconstrained <- function
+(count.vec,
+ weight.vec=rep(1, length(count.vec)),
+ penalty=NULL
+){
+  n.data <- length(count.vec)
+  stopifnot(2 <= n.data)
+  stopifnot(is.integer(count.vec))
+  stopifnot(0 <= count.vec)
+  stopifnot(is.numeric(weight.vec))
+  stopifnot(n.data == length(weight.vec))
+  stopifnot(0 < weight.vec)
+  stopifnot(is.numeric(penalty))
+  stopifnot(length(penalty) == 1)
+  stopifnot(0 <= penalty)
+  cost.vec <- double(n.data)
+  end.vec <- integer(n.data)
+  mean.vec <- double(n.data)
+  intervals.vec <- integer(n.data)
+  result.list <- .C(
+    "PoissonFPOPunconstrained_interface",
+    count.vec=as.integer(count.vec),
+    weight.vec=as.numeric(weight.vec),
+    n.data=as.integer(n.data),
+    penalty=as.numeric(penalty),
+    cost.vec=as.double(cost.vec),
+    end.vec=as.integer(end.vec),
+    mean.vec=as.double(mean.vec),
+    intervals.vec=as.integer(intervals.vec),
+    PACKAGE="PeakSegOptimal")
+  n.segments <- sum(result.list$end.vec != -2L)
+  if(n.segments == 0) n.segments <- 1L
+  seg.mean <- rev(result.list$mean.vec[1:n.segments])
+  seg.end <- rev(result.list$end.vec[1:n.segments])
+  result.list$seg.mean <- seg.mean
+  result.list$seg.end <- seg.end + 1L
+  result.list$n.segments <- n.segments
+  result.list
+}

--- a/README.org
+++ b/README.org
@@ -6,7 +6,7 @@ PeakSegOptimal: Optimal Segmentation Subject to Up-Down Constraints
 
 Two new FPOP solvers for the Medium and Hard tests:
 
-- =PoissonFPOPunconstrained= — unconstrained optimal partitioning (Poisson loss). 2-state up/down model collapsed to 1 state, monotonicity operators replaced with =set_to_unconstrained_min_of=. Validated against =Segmentor3IsBack::Segmentor(model=1)=.
+- =PoissonFPOPunconstrained= — unconstrained optimal partitioning (Poisson loss). 2-state up/down model collapsed to 1 state, monotonicity operators replaced with =set_to_unconstrained_min_of=.
 - =NormalFPOPisotonic= — regularized isotonic regression (Normal loss). Uses =set_to_min_less_of= for non-decreasing constraint. =NormalLossPiece= inherits from a shared =LossPiece= base class alongside =PoissonLossPieceLog=. Validated against =isoreg()= (penalty=0) and =fpop::Fpop()=.
 
 *** Run the tests
@@ -29,7 +29,6 @@ test_file("tests/testthat/test-NormalFPOPisotonic.R")         ## 17 tests
 Passes =R CMD check --no-manual= with no new warnings.
 
 Optional (tests skip gracefully if missing):
-- =remotes::install_github("cran/Segmentor3IsBack")=
 - =install.packages("fpop")=
 
 *** What changed

--- a/README.org
+++ b/README.org
@@ -2,6 +2,48 @@ PeakSegOptimal: Optimal Segmentation Subject to Up-Down Constraints
 
 [[https://travis-ci.org/tdhock/PeakSegOptimal][https://travis-ci.org/tdhock/PeakSegOptimal.png?branch=master]]
 
+** [[https://github.com/rstats-gsoc/gsoc2026/wiki/gfpop][GSoC 2026]]: New solvers
+
+Two new FPOP solvers for the Medium and Hard tests:
+
+- =PoissonFPOPunconstrained= — unconstrained optimal partitioning (Poisson loss). 2-state up/down model collapsed to 1 state, monotonicity operators replaced with =set_to_unconstrained_min_of=. Validated against =Segmentor3IsBack::Segmentor(model=1)=.
+- =NormalFPOPisotonic= — regularized isotonic regression (Normal loss). Uses =set_to_min_less_of= for non-decreasing constraint. =NormalLossPiece= inherits from a shared =LossPiece= base class alongside =PoissonLossPieceLog=. Validated against =isoreg()= (penalty=0) and =fpop::Fpop()=.
+
+*** Run the tests
+
+From the package root:
+
+#+BEGIN_SRC bash
+git clone https://github.com/williamzhang7792/PeakSegOptimal.git
+cd PeakSegOptimal
+R CMD INSTALL .
+#+END_SRC
+
+#+BEGIN_SRC R
+library(testthat)
+library(PeakSegOptimal)
+test_file("tests/testthat/test-PoissonFPOPunconstrained.R")  ## 28 tests
+test_file("tests/testthat/test-NormalFPOPisotonic.R")         ## 17 tests
+#+END_SRC
+
+Passes =R CMD check --no-manual= with no new warnings.
+
+Optional (tests skip gracefully if missing):
+- =remotes::install_github("cran/Segmentor3IsBack")=
+- =install.packages("fpop")=
+
+*** What changed
+
+New files: =src/PoissonFPOPunconstrained.{cpp,h}=, =src/NormalFPOPisotonic.{cpp,h}=,
+=src/LossPiece.h=, =R/PoissonFPOPunconstrained.R=, =R/NormalFPOPisotonic.R=,
+=man/PoissonFPOPunconstrained.Rd=, =man/NormalFPOPisotonic.Rd=,
+=tests/testthat/test-PoissonFPOPunconstrained.R=, =tests/testthat/test-NormalFPOPisotonic.R=.
+
+Modified: =src/funPieceListLog.{h,cpp}= (added =set_to_unconstrained_min_of=),
+=src/interface.cpp= (registered new C entry points), =NAMESPACE=.
+
+-----
+
 NOTE: the name of the package has been changed from coseg to PeakSegOptimal, to
 avoid confusion with the [[https://cran.r-project.org/web/packages/CoSeg/index.html][CoSeg]] package on CRAN (which is completely
 unrelated to this package).

--- a/man/NormalFPOPisotonic.Rd
+++ b/man/NormalFPOPisotonic.Rd
@@ -1,0 +1,25 @@
+\name{NormalFPOPisotonic}
+\alias{NormalFPOPisotonic}
+\title{Isotonic Regression via Normal FPOP}
+\description{Regularized isotonic regression using the Normal
+(Gaussian/quadratic) loss with a non-decreasing constraint on
+segment means. Uses the functional pruning optimal partitioning (FPOP)
+algorithm.}
+\usage{NormalFPOPisotonic(data.vec,
+    penalty = NULL)}
+\arguments{
+  \item{data.vec}{numeric vector of data to segment.}
+  \item{penalty}{non-negative numeric scalar: penalty for each changepoint.
+  Use \code{penalty=0} for unpenalized isotonic regression (equivalent to
+  \code{\link{isoreg}}).}
+}
+\value{List with elements \code{seg.mean} (segment means in
+chronological order, non-decreasing), \code{seg.end} (1-indexed segment
+ends), \code{n.segments} (number of segments), \code{cost.vec},
+\code{end.vec}, \code{mean.vec}, \code{intervals.vec}.}
+\examples{
+library(PeakSegOptimal)
+y <- c(5, 3, 4, 1, 2, 8, 7, 9)
+fit <- NormalFPOPisotonic(y, penalty=0)
+fit$seg.mean
+}

--- a/man/PoissonFPOPunconstrained.Rd
+++ b/man/PoissonFPOPunconstrained.Rd
@@ -1,0 +1,27 @@
+\name{PoissonFPOPunconstrained}
+\alias{PoissonFPOPunconstrained}
+\title{Unconstrained Poisson FPOP}
+\description{Optimal changepoint detection using the Poisson loss
+without any constraint on segment mean changes (no up-down PeakSeg
+constraint). Uses the functional pruning optimal partitioning (FPOP)
+algorithm which is O(N log N) time and memory.}
+\usage{PoissonFPOPunconstrained(count.vec,
+    weight.vec = rep(1,
+        length(count.vec)),
+    penalty = NULL)}
+\arguments{
+  \item{count.vec}{integer vector of non-negative count data to segment.}
+  \item{weight.vec}{numeric vector (same length as count.vec) of positive weights.}
+  \item{penalty}{non-negative numeric scalar: penalty for each changepoint.}
+}
+\value{List with elements \code{seg.mean} (segment means in
+chronological order), \code{seg.end} (1-indexed segment ends),
+\code{n.segments} (number of segments), \code{cost.vec},
+\code{end.vec}, \code{mean.vec}, \code{intervals.vec}.}
+\examples{
+library(PeakSegOptimal)
+data.vec <- as.integer(c(3,5,7,4,6,2, 18,22,15,20,19,25, 4,6,3,5,7,2))
+fit <- PoissonFPOPunconstrained(data.vec, penalty=10)
+fit$n.segments
+fit$seg.mean
+}

--- a/src/LossPiece.h
+++ b/src/LossPiece.h
@@ -1,0 +1,20 @@
+#ifndef LOSS_PIECE_H
+#define LOSS_PIECE_H
+
+class LossPiece {
+public:
+  double min_mean, max_mean;
+  int data_i;
+  double prev_mean;
+
+  LossPiece() : min_mean(0), max_mean(0), data_i(0), prev_mean(0) {}
+  LossPiece(double m, double M, int i, double prev)
+    : min_mean(m), max_mean(M), data_i(i), prev_mean(prev) {}
+  double clamp_to_interval(double x) const {
+    if(x < min_mean) return min_mean;
+    if(x > max_mean) return max_mean;
+    return x;
+  }
+};
+
+#endif

--- a/src/NormalFPOPisotonic.cpp
+++ b/src/NormalFPOPisotonic.cpp
@@ -1,0 +1,613 @@
+/* -*- compile-command: "R CMD INSTALL .." -*- */
+
+#include <R.h>
+#include <math.h>
+#include <list>
+#include <vector>
+
+#include "LossPiece.h"
+#include "NormalFPOPisotonic.h"
+
+#define EPSILON 1e-12
+#define ABS(x) ((x)<0 ? -(x) : (x))
+#define ERROR_MIN_MAX_SAME 1
+
+class NormalLossPiece : public LossPiece {
+public:
+  double Quadratic, Linear, Constant;
+  NormalLossPiece();
+  NormalLossPiece(double q, double l, double c,
+                  double m, double M, int i, double prev);
+  double getCost(double mean);
+  double argmin();
+  double argmin_interval();
+  bool has_two_roots(double equals);
+  double get_smaller_root(double equals);
+  double get_larger_root(double equals);
+  void print();
+};
+
+typedef std::list<NormalLossPiece> NormalLossPieceList;
+
+class PiecewiseNormalLoss {
+public:
+  NormalLossPieceList piece_list;
+  void set_to_min_less_of(PiecewiseNormalLoss *input);
+  void set_to_min_env_of(PiecewiseNormalLoss *fun1,
+                         PiecewiseNormalLoss *fun2, int verbose);
+  void push_min_pieces(PiecewiseNormalLoss *fun1,
+                       PiecewiseNormalLoss *fun2,
+                       NormalLossPieceList::iterator it1,
+                       NormalLossPieceList::iterator it2, int verbose);
+  void push_piece(NormalLossPieceList::iterator it,
+                  double min_mean, double max_mean);
+  void add(double Quadratic, double Linear, double Constant);
+  void multiply(double x);
+  void set_prev_seg_end(int prev_seg_end);
+  void findMean(double mean, int *seg_end, double *prev_mean);
+  double findCost(double mean);
+  void Minimize(double *best_cost, double *best_mean,
+                int *data_i, double *prev_mean);
+  void print();
+};
+
+bool sameFuns(NormalLossPieceList::iterator it1,
+              NormalLossPieceList::iterator it2);
+
+NormalLossPiece::NormalLossPiece()
+  : LossPiece(), Quadratic(0), Linear(0), Constant(0) {}
+
+NormalLossPiece::NormalLossPiece
+(double q, double l, double c, double m, double M, int i, double prev)
+  : LossPiece(m, M, i, prev), Quadratic(q), Linear(l), Constant(c) {}
+
+double NormalLossPiece::getCost(double mean){
+  return Quadratic*mean*mean + Linear*mean + Constant;
+}
+
+double NormalLossPiece::argmin(){
+  if(Quadratic == 0){
+    if(Linear < 0) return INFINITY;
+    if(Linear > 0) return -INFINITY;
+    return 0;
+  }
+  return -Linear / (2.0*Quadratic);
+}
+
+double NormalLossPiece::argmin_interval(){
+  double a = argmin();
+  if(a < min_mean) return min_mean;
+  if(a > max_mean) return max_mean;
+  return a;
+}
+
+bool NormalLossPiece::has_two_roots(double equals){
+  if(Quadratic == 0) return false;
+  double disc = Linear*Linear - 4.0*Quadratic*(Constant - equals);
+  return disc > EPSILON;
+}
+
+double NormalLossPiece::get_smaller_root(double equals){
+  double a = Quadratic, b = Linear, c = Constant - equals;
+  if(a == 0){
+    if(b == 0) return -INFINITY;
+    return -c/b;
+  }
+  double disc = b*b - 4.0*a*c;
+  if(disc < 0) disc = 0;
+  double r1 = (-b - sqrt(disc)) / (2.0*a);
+  double r2 = (-b + sqrt(disc)) / (2.0*a);
+  return (r1 < r2) ? r1 : r2;
+}
+
+double NormalLossPiece::get_larger_root(double equals){
+  double a = Quadratic, b = Linear, c = Constant - equals;
+  if(a == 0){
+    if(b == 0) return INFINITY;
+    return -c/b;
+  }
+  double disc = b*b - 4.0*a*c;
+  if(disc < 0) disc = 0;
+  double r1 = (-b - sqrt(disc)) / (2.0*a);
+  double r2 = (-b + sqrt(disc)) / (2.0*a);
+  return (r1 > r2) ? r1 : r2;
+}
+
+void NormalLossPiece::print(){
+  Rprintf("%.10e %.10e %.10e %15f %15f %15f %d\n",
+          Quadratic, Linear, Constant,
+          min_mean, max_mean, prev_mean, data_i);
+}
+
+void PiecewiseNormalLoss::add
+(double Quadratic, double Linear, double Constant){
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    it->Quadratic += Quadratic;
+    it->Linear += Linear;
+    it->Constant += Constant;
+  }
+}
+
+void PiecewiseNormalLoss::multiply(double x){
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    it->Quadratic *= x;
+    it->Linear *= x;
+    it->Constant *= x;
+  }
+}
+
+void PiecewiseNormalLoss::set_prev_seg_end(int prev_seg_end){
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    it->data_i = prev_seg_end;
+  }
+}
+
+void PiecewiseNormalLoss::findMean
+(double mean, int *seg_end, double *prev_mean_out){
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    if(it->min_mean <= mean && mean <= it->max_mean){
+      *seg_end = it->data_i;
+      *prev_mean_out = it->prev_mean;
+      return;
+    }
+  }
+  Rf_error("findMean: mean=%e outside all piece intervals", mean);
+}
+
+double PiecewiseNormalLoss::findCost(double mean){
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    if(it->min_mean <= mean && mean <= it->max_mean){
+      return it->getCost(mean);
+    }
+  }
+  return INFINITY;
+}
+
+void PiecewiseNormalLoss::Minimize
+(double *best_cost, double *best_mean,
+ int *data_i, double *prev_mean_out){
+  double candidate_cost, candidate_mean;
+  *best_cost = INFINITY;
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    candidate_mean = it->argmin_interval();
+    candidate_cost = it->getCost(candidate_mean);
+    if(candidate_cost < *best_cost){
+      *best_cost = candidate_cost;
+      *best_mean = candidate_mean;
+      *data_i = it->data_i;
+      *prev_mean_out = it->prev_mean;
+    }
+  }
+}
+
+void PiecewiseNormalLoss::print(){
+  Rprintf("%10s %10s %15s %15s %15s %15s %s\n",
+          "Quadratic", "Linear", "Constant",
+          "min_mean", "max_mean", "prev_mean", "data_i");
+  for(auto it = piece_list.begin(); it != piece_list.end(); it++){
+    it->print();
+  }
+}
+
+void PiecewiseNormalLoss::set_to_min_less_of
+(PiecewiseNormalLoss *input){
+  piece_list.clear();
+
+  auto it = input->piece_list.begin();
+  double right_bound = it->min_mean;
+  double cur_value   = it->getCost(right_bound);
+
+  piece_list.emplace_back(
+    0.0, 0.0, cur_value,
+    right_bound, right_bound,
+    it->data_i, right_bound);
+
+  bool const_piece;
+  {
+    double arg0 = it->argmin();
+    bool not_const = !(it->Quadratic == 0 && it->Linear == 0);
+    const_piece = (arg0 <= right_bound && not_const);
+  }
+
+  for(; it != input->piece_list.end(); ++it){
+    double argmin_clamp = it->clamp_to_interval(it->argmin());
+    double piece_min    = it->getCost(argmin_clamp);
+
+    double decr_a = INFINITY, decr_b = INFINITY;
+    bool piece_beats_cur = (piece_min + EPSILON < cur_value);
+    bool argmin_ahead    = (right_bound < it->argmin());
+
+    if(piece_beats_cur && argmin_ahead){
+      if(const_piece){
+        double root = it->get_smaller_root(cur_value);
+        if(root < right_bound)   root = right_bound;
+        if(root < it->min_mean)  root = it->min_mean;
+        if(root > argmin_clamp)  root = right_bound;
+        decr_a = root;
+      } else {
+        decr_a = right_bound;
+      }
+      decr_b = argmin_clamp;
+    } else if(ABS(piece_min - cur_value) < EPSILON && argmin_ahead){
+      decr_a = right_bound;
+      decr_b = it->max_mean;
+    }
+
+    if(decr_a != INFINITY && decr_a < it->min_mean) decr_a = it->min_mean;
+    bool has_decr = (decr_a != INFINITY && decr_a < decr_b);
+
+    auto &last = piece_list.back();
+    if(!has_decr){
+      if(last.Quadratic == 0 && last.Linear == 0){
+        last.max_mean = it->max_mean;
+      } else {
+        piece_list.emplace_back(
+          0.0, 0.0, cur_value,
+          right_bound, it->max_mean,
+          last.data_i, right_bound);
+      }
+    } else {
+      if(decr_a > last.min_mean){
+        last.max_mean = decr_a;
+      } else {
+        piece_list.pop_back();
+      }
+
+      if(decr_a < decr_b){
+        piece_list.emplace_back(
+          it->Quadratic, it->Linear, it->Constant,
+          decr_a, decr_b,
+          it->data_i, INFINITY);
+      }
+
+      if(decr_b < it->max_mean){
+        double out_value = it->getCost(decr_b);
+        piece_list.emplace_back(
+          0.0, 0.0, out_value,
+          decr_b, it->max_mean,
+          it->data_i, decr_b);
+      }
+    }
+
+    auto &new_last = piece_list.back();
+    right_bound = new_last.max_mean;
+    cur_value   = new_last.getCost(right_bound);
+    const_piece = (new_last.Quadratic == 0 && new_last.Linear == 0);
+  }
+}
+
+bool sameFuns
+(NormalLossPieceList::iterator it1,
+ NormalLossPieceList::iterator it2){
+  return it1->Quadratic == it2->Quadratic &&
+    it1->Linear == it2->Linear &&
+    ABS(it1->Constant - it2->Constant) < EPSILON;
+}
+
+void PiecewiseNormalLoss::push_piece
+(NormalLossPieceList::iterator it,
+ double min_mean, double max_mean){
+  if(max_mean <= min_mean) return;
+  NormalLossPieceList::iterator last = piece_list.end();
+  --last;
+  if(piece_list.size() &&
+     sameFuns(last, it) &&
+     it->prev_mean == last->prev_mean &&
+     it->data_i == last->data_i){
+    last->max_mean = max_mean;
+  }else{
+    piece_list.emplace_back(
+      it->Quadratic, it->Linear, it->Constant,
+      min_mean, max_mean,
+      it->data_i, it->prev_mean);
+  }
+}
+
+void PiecewiseNormalLoss::push_min_pieces
+(PiecewiseNormalLoss *fun1,
+ PiecewiseNormalLoss *fun2,
+ NormalLossPieceList::iterator it1,
+ NormalLossPieceList::iterator it2,
+ int verbose){
+  bool same_at_left;
+  double last_min_mean;
+  NormalLossPieceList::iterator prev2 = it2;
+  prev2--;
+  NormalLossPieceList::iterator prev1 = it1;
+  prev1--;
+  if(it1->min_mean < it2->min_mean){
+    same_at_left = sameFuns(prev2, it1);
+    last_min_mean = it2->min_mean;
+  }else{
+    last_min_mean = it1->min_mean;
+    if(it2->min_mean < it1->min_mean){
+      same_at_left = sameFuns(prev1, it2);
+    }else{
+      if(it1 == fun1->piece_list.begin() &&
+         it2 == fun2->piece_list.begin()){
+        same_at_left = false;
+      }else{
+        same_at_left = sameFuns(prev1, prev2);
+      }
+    }
+  }
+  NormalLossPieceList::iterator next2 = it2;
+  next2++;
+  NormalLossPieceList::iterator next1 = it1;
+  next1++;
+  bool same_at_right;
+  double first_max_mean;
+  if(it1->max_mean < it2->max_mean){
+    same_at_right = sameFuns(next1, it2);
+    first_max_mean = it1->max_mean;
+  }else{
+    first_max_mean = it2->max_mean;
+    if(it2->max_mean < it1->max_mean){
+      same_at_right = sameFuns(it1, next2);
+    }else{
+      if(next1 == fun1->piece_list.end() &&
+         next2 == fun2->piece_list.end()){
+        same_at_right = false;
+      }else{
+        same_at_right = sameFuns(next1, next2);
+      }
+    }
+  }
+  if(last_min_mean == first_max_mean) return;
+  if(sameFuns(it1, it2)){
+    push_piece(it1, last_min_mean, first_max_mean);
+    return;
+  }
+  NormalLossPiece diff_piece(
+    it1->Quadratic - it2->Quadratic,
+    it1->Linear    - it2->Linear,
+    it1->Constant  - it2->Constant,
+    last_min_mean, first_max_mean, -5, 0.0);
+  double mid_mean      = (first_max_mean + last_min_mean) / 2;
+  double cost_diff_mid = diff_piece.getCost(mid_mean);
+  if(same_at_left && same_at_right){
+    if(cost_diff_mid < 0){
+      push_piece(it1, last_min_mean, first_max_mean);
+    }else{
+      push_piece(it2, last_min_mean, first_max_mean);
+    }
+    return;
+  }
+  if(diff_piece.Quadratic == 0){
+    if(diff_piece.Linear == 0){
+      if(diff_piece.Constant < 0){
+        push_piece(it1, last_min_mean, first_max_mean);
+      }else{
+        push_piece(it2, last_min_mean, first_max_mean);
+      }
+      return;
+    }
+    double mean_at_equal_cost = -diff_piece.Constant / diff_piece.Linear;
+    if(last_min_mean < mean_at_equal_cost &&
+       mean_at_equal_cost < first_max_mean){
+      if(0 < diff_piece.Linear){
+        push_piece(it1, last_min_mean, mean_at_equal_cost);
+        push_piece(it2, mean_at_equal_cost, first_max_mean);
+      }else{
+        push_piece(it2, last_min_mean, mean_at_equal_cost);
+        push_piece(it1, mean_at_equal_cost, first_max_mean);
+      }
+      return;
+    }
+    if(cost_diff_mid < 0){
+      push_piece(it1, last_min_mean, first_max_mean);
+    }else{
+      push_piece(it2, last_min_mean, first_max_mean);
+    }
+    return;
+  }
+  double cost_diff_left  = diff_piece.getCost(last_min_mean);
+  double cost_diff_right = diff_piece.getCost(first_max_mean);
+  bool two_roots = diff_piece.has_two_roots(0.0);
+  double smaller_mean, larger_mean;
+  if(two_roots){
+    smaller_mean = diff_piece.get_smaller_root(0.0);
+    larger_mean  = diff_piece.get_larger_root(0.0);
+  }
+  if(same_at_right){
+    if(two_roots){
+      double mean_at_crossing = smaller_mean;
+      double mean_at_optimum  = diff_piece.argmin();
+      if(last_min_mean < mean_at_crossing &&
+         mean_at_crossing < mean_at_optimum &&
+         mean_at_optimum < first_max_mean){
+        if(cost_diff_left < 0){
+          push_piece(it1, last_min_mean, mean_at_crossing);
+          push_piece(it2, mean_at_crossing, first_max_mean);
+        }else{
+          push_piece(it2, last_min_mean, mean_at_crossing);
+          push_piece(it1, mean_at_crossing, first_max_mean);
+        }
+        return;
+      }
+    }
+    if(cost_diff_mid < 0){
+      push_piece(it1, last_min_mean, first_max_mean);
+    }else{
+      push_piece(it2, last_min_mean, first_max_mean);
+    }
+    return;
+  }
+  if(same_at_left){
+    if(two_roots){
+      double mean_at_crossing = larger_mean;
+      double mean_at_optimum  = diff_piece.argmin();
+      if(last_min_mean < mean_at_optimum &&
+         mean_at_optimum < mean_at_crossing &&
+         mean_at_crossing < first_max_mean){
+        if(cost_diff_right < 0){
+          push_piece(it2, last_min_mean, mean_at_crossing);
+          push_piece(it1, mean_at_crossing, first_max_mean);
+        }else{
+          push_piece(it1, last_min_mean, mean_at_crossing);
+          push_piece(it2, mean_at_crossing, first_max_mean);
+        }
+        return;
+      }
+    }
+    if(cost_diff_mid < 0){
+      push_piece(it1, last_min_mean, first_max_mean);
+    }else{
+      push_piece(it2, last_min_mean, first_max_mean);
+    }
+    return;
+  }
+  double first_mean_cross = INFINITY, second_mean_cross = INFINITY;
+  if(two_roots){
+    bool larger_inside  =
+      last_min_mean < larger_mean  && larger_mean  < first_max_mean;
+    bool smaller_inside =
+      last_min_mean < smaller_mean && smaller_mean < first_max_mean;
+    if(larger_inside){
+      if(smaller_inside && smaller_mean < larger_mean){
+        first_mean_cross  = smaller_mean;
+        second_mean_cross = larger_mean;
+      }else{
+        first_mean_cross = larger_mean;
+      }
+    }else{
+      if(smaller_inside){
+        first_mean_cross = smaller_mean;
+      }
+    }
+  }
+  if(second_mean_cross != INFINITY){
+    double before_mean      = (last_min_mean + first_mean_cross) / 2;
+    double cost_diff_before = diff_piece.getCost(before_mean);
+    if(cost_diff_before < 0){
+      push_piece(it1, last_min_mean, first_mean_cross);
+      push_piece(it2, first_mean_cross, second_mean_cross);
+      push_piece(it1, second_mean_cross, first_max_mean);
+    }else{
+      push_piece(it2, last_min_mean, first_mean_cross);
+      push_piece(it1, first_mean_cross, second_mean_cross);
+      push_piece(it2, second_mean_cross, first_max_mean);
+    }
+  }else if(first_mean_cross != INFINITY){
+    double before_mean      = (last_min_mean + first_mean_cross) / 2;
+    double cost_diff_before = diff_piece.getCost(before_mean);
+    double after_mean       = (first_max_mean + first_mean_cross) / 2;
+    double cost_diff_after  = diff_piece.getCost(after_mean);
+    if(cost_diff_before < 0){
+      if(cost_diff_after < 0){
+        push_piece(it1, last_min_mean, first_max_mean);
+      }else{
+        push_piece(it1, last_min_mean, first_mean_cross);
+        push_piece(it2, first_mean_cross, first_max_mean);
+      }
+    }else{
+      if(cost_diff_after < 0){
+        push_piece(it2, last_min_mean, first_mean_cross);
+        push_piece(it1, first_mean_cross, first_max_mean);
+      }else{
+        push_piece(it2, last_min_mean, first_max_mean);
+      }
+    }
+  }else{
+    double cost_diff;
+    if(first_max_mean == INFINITY){
+      cost_diff = diff_piece.getCost(last_min_mean + 1);
+    }else{
+      if(ABS(cost_diff_mid) < EPSILON){
+        cost_diff = cost_diff_right;
+      }else{
+        cost_diff = cost_diff_mid;
+      }
+    }
+    if(cost_diff < 0){
+      push_piece(it1, last_min_mean, first_max_mean);
+    }else{
+      push_piece(it2, last_min_mean, first_max_mean);
+    }
+  }
+}
+
+void PiecewiseNormalLoss::set_to_min_env_of
+(PiecewiseNormalLoss *fun1, PiecewiseNormalLoss *fun2, int verbose){
+  NormalLossPieceList::iterator
+    it1 = fun1->piece_list.begin(),
+    it2 = fun2->piece_list.begin();
+  piece_list.clear();
+  while(it1 != fun1->piece_list.end() &&
+        it2 != fun2->piece_list.end()){
+    push_min_pieces(fun1, fun2, it1, it2, verbose);
+    double last_max_mean = piece_list.back().max_mean;
+    if(it1->max_mean == last_max_mean) it1++;
+    if(it2->max_mean == last_max_mean) it2++;
+  }
+}
+
+int NormalFPOPisotonic
+(double *data_vec, int data_count,
+ double penalty,
+ double *cost_vec,
+ int *end_vec,
+ double *mean_vec,
+ int *intervals_vec){
+  double min_mean = INFINITY, max_mean = -INFINITY;
+  for(int data_i = 0; data_i < data_count; data_i++){
+    if(data_vec[data_i] < min_mean) min_mean = data_vec[data_i];
+    if(max_mean < data_vec[data_i]) max_mean = data_vec[data_i];
+  }
+  if(min_mean == max_mean){
+    return ERROR_MIN_MAX_SAME;
+  }
+
+  std::vector<PiecewiseNormalLoss> cost_model_mat(data_count);
+  PiecewiseNormalLoss *cost, *cost_prev;
+  PiecewiseNormalLoss min_prev_cost;
+  int verbose = 0;
+
+  for(int data_i = 0; data_i < data_count; data_i++){
+    cost = &cost_model_mat[data_i];
+    double y = data_vec[data_i];
+
+    if(data_i == 0){
+      cost->piece_list.emplace_back(
+        1.0, -2.0*y, y*y,
+        min_mean, max_mean, -1, INFINITY);
+    }else{
+      min_prev_cost.set_to_min_less_of(cost_prev);
+      min_prev_cost.set_prev_seg_end(data_i - 1);
+      min_prev_cost.add(0.0, 0.0, penalty);
+      cost->set_to_min_env_of(&min_prev_cost, cost_prev, verbose);
+      cost->add(1.0, -2.0*y, y*y);
+    }
+    cost_prev = cost;
+  }
+
+  double best_cost, best_mean, prev_mean_val;
+  int prev_seg_end;
+  for(int i = 0; i < data_count; i++){
+    cost = &cost_model_mat[i];
+    intervals_vec[i] = cost->piece_list.size();
+    cost->Minimize(cost_vec+i, &best_mean, &prev_seg_end, &prev_mean_val);
+  }
+
+  cost_model_mat[data_count-1].Minimize(
+    &best_cost, &best_mean, &prev_seg_end, &prev_mean_val);
+
+  for(int i = 0; i < data_count; i++){
+    mean_vec[i] = INFINITY;
+    end_vec[i] = -2;
+  }
+  mean_vec[0] = best_mean;
+  end_vec[0] = prev_seg_end;
+  int out_i = 1;
+  while(0 <= prev_seg_end && out_i < data_count){
+    cost = &cost_model_mat[prev_seg_end];
+    if(prev_mean_val != INFINITY){
+      best_mean = prev_mean_val;
+    }
+    cost->findMean(best_mean, &prev_seg_end, &prev_mean_val);
+    mean_vec[out_i] = best_mean;
+    end_vec[out_i] = prev_seg_end;
+    out_i++;
+  }
+  return 0;
+}

--- a/src/NormalFPOPisotonic.cpp
+++ b/src/NormalFPOPisotonic.cpp
@@ -5,12 +5,12 @@
 #include <list>
 #include <vector>
 
+#include "funPieceListLog.h"
 #include "LossPiece.h"
 #include "NormalFPOPisotonic.h"
 
 #define EPSILON 1e-12
 #define ABS(x) ((x)<0 ? -(x) : (x))
-#define ERROR_MIN_MAX_SAME 1
 
 class NormalLossPiece : public LossPiece {
 public:
@@ -568,10 +568,13 @@ int NormalFPOPisotonic
     double y = data_vec[data_i];
 
     if(data_i == 0){
+      // C_1(m) = (m - y_1)^2 = m^2 - 2*y_1*m + y_1^2
       cost->piece_list.emplace_back(
         1.0, -2.0*y, y*y,
         min_mean, max_mean, -1, INFINITY);
     }else{
+      // C_t(m) = (m - y_t)^2 + min{ C_{t-1}(m), C^{<=}_{t-1}(m) + lambda }
+      // where C^{<=} enforces the non-decreasing (isotonic) constraint.
       min_prev_cost.set_to_min_less_of(cost_prev);
       min_prev_cost.set_prev_seg_end(data_i - 1);
       min_prev_cost.add(0.0, 0.0, penalty);

--- a/src/NormalFPOPisotonic.h
+++ b/src/NormalFPOPisotonic.h
@@ -1,0 +1,7 @@
+int NormalFPOPisotonic
+(double *data_vec, int data_count,
+ double penalty,
+ double *cost_vec,
+ int *end_vec,
+ double *mean_vec,
+ int *intervals_vec);

--- a/src/PoissonFPOPunconstrained.cpp
+++ b/src/PoissonFPOPunconstrained.cpp
@@ -33,10 +33,13 @@ int PoissonFPOPunconstrainedLog
     cost = &cost_model_mat[data_i];
     cum_weight_i += weight_vec[data_i];
     if(data_i==0){
+      // C_1(m) = gamma_1(m)/w_1
       cost->piece_list.emplace_back(
         1.0, -data_vec[0], 0.0,
         min_log_mean, max_log_mean, -1, INFINITY);
     }else{
+      // C_t(m) = (gamma_t + w_{1:t-1} * M_t(m)) / w_{1:t}, where
+      // M_t(m) = min{ C_{t-1}(m), min_m' C_{t-1}(m') + lambda/w_{1:t-1} }
       min_prev_cost.set_to_unconstrained_min_of(cost_prev);
       min_prev_cost.set_prev_seg_end(data_i-1);
       min_prev_cost.add(0.0, 0.0, penalty/cum_weight_prev_i);

--- a/src/PoissonFPOPunconstrained.cpp
+++ b/src/PoissonFPOPunconstrained.cpp
@@ -1,0 +1,81 @@
+/* -*- compile-command: "R CMD INSTALL .." -*- */
+
+#include <vector>
+#include <math.h>
+#include "funPieceListLog.h"
+#include "PoissonFPOPunconstrained.h"
+
+int PoissonFPOPunconstrainedLog
+(int *data_vec, double *weight_vec, int data_count,
+ double penalty,
+ double *cost_vec,
+ int *end_vec,
+ double *mean_vec,
+ int *intervals_vec){
+  double min_log_mean=INFINITY, max_log_mean=-INFINITY;
+  for(int data_i=0; data_i<data_count; data_i++){
+    if(data_vec[data_i] < 0) return ERROR_NEGATIVE_DATA;
+    double log_data = log((double)data_vec[data_i]);
+    if(log_data < min_log_mean) min_log_mean = log_data;
+    if(max_log_mean < log_data) max_log_mean = log_data;
+  }
+  if(min_log_mean == max_log_mean){
+    return ERROR_MIN_MAX_SAME;
+  }
+
+  std::vector<PiecewisePoissonLossLog> cost_model_mat(data_count);
+  PiecewisePoissonLossLog *cost, *cost_prev;
+  PiecewisePoissonLossLog min_prev_cost;
+  int verbose = 0;
+  double cum_weight_i = 0.0, cum_weight_prev_i;
+
+  for(int data_i=0; data_i<data_count; data_i++){
+    cost = &cost_model_mat[data_i];
+    cum_weight_i += weight_vec[data_i];
+    if(data_i==0){
+      cost->piece_list.emplace_back(
+        1.0, -data_vec[0], 0.0,
+        min_log_mean, max_log_mean, -1, INFINITY);
+    }else{
+      min_prev_cost.set_to_unconstrained_min_of(cost_prev);
+      min_prev_cost.set_prev_seg_end(data_i-1);
+      min_prev_cost.add(0.0, 0.0, penalty/cum_weight_prev_i);
+      cost->set_to_min_env_of(&min_prev_cost, cost_prev, verbose);
+      cost->multiply(cum_weight_prev_i);
+      cost->add(
+        weight_vec[data_i],
+        -data_vec[data_i]*weight_vec[data_i],
+        0.0);
+      cost->multiply(1.0/cum_weight_i);
+    }
+    cum_weight_prev_i = cum_weight_i;
+    cost_prev = cost;
+  }
+
+  double best_log_mean, prev_log_mean;
+  int prev_seg_end;
+  for(int i=0; i<data_count; i++){
+    cost = &cost_model_mat[i];
+    intervals_vec[i] = cost->piece_list.size();
+    cost->Minimize(cost_vec+i, &best_log_mean, &prev_seg_end, &prev_log_mean);
+  }
+
+  for(int i=0; i<data_count; i++){
+    mean_vec[i] = INFINITY;
+    end_vec[i] = -2;
+  }
+  mean_vec[0] = exp(best_log_mean);
+  end_vec[0] = prev_seg_end;
+  int out_i=1;
+  while(0 <= prev_seg_end && out_i < data_count){
+    cost = &cost_model_mat[prev_seg_end];
+    if(prev_log_mean != INFINITY){
+      best_log_mean = prev_log_mean;
+    }
+    cost->findMean(best_log_mean, &prev_seg_end, &prev_log_mean);
+    mean_vec[out_i] = exp(best_log_mean);
+    end_vec[out_i] = prev_seg_end;
+    out_i++;
+  }
+  return 0;
+}

--- a/src/PoissonFPOPunconstrained.h
+++ b/src/PoissonFPOPunconstrained.h
@@ -1,0 +1,9 @@
+#define ERROR_NEGATIVE_DATA 2
+
+int PoissonFPOPunconstrainedLog
+(int *data_vec, double *weight_vec,
+ int data_count, double penalty,
+ double *cost_vec,
+ int *end_vec,
+ double *mean_vec,
+ int *intervals_vec);

--- a/src/funPieceListLog.cpp
+++ b/src/funPieceListLog.cpp
@@ -1208,3 +1208,16 @@ void PiecewisePoissonLossLog::push_piece
        it->data_i, it->prev_log_mean);
   }
 }
+
+void PiecewisePoissonLossLog::set_to_unconstrained_min_of
+(PiecewisePoissonLossLog *input){
+  double best_cost, best_log_mean, prev_log_mean_val;
+  int prev_seg_end;
+  input->Minimize(&best_cost, &best_log_mean, &prev_seg_end, &prev_log_mean_val);
+  piece_list.clear();
+  piece_list.emplace_back(
+    0.0, 0.0, best_cost,
+    input->piece_list.front().min_log_mean,
+    input->piece_list.back().max_log_mean,
+    prev_seg_end, best_log_mean);
+}

--- a/src/funPieceListLog.h
+++ b/src/funPieceListLog.h
@@ -40,6 +40,7 @@ class PiecewisePoissonLossLog {
   PoissonLossPieceListLog piece_list;
   void set_to_min_less_of(PiecewisePoissonLossLog *, int);
   void set_to_min_more_of(PiecewisePoissonLossLog *, int);
+  void set_to_unconstrained_min_of(PiecewisePoissonLossLog *);
   void set_to_min_env_of
     (PiecewisePoissonLossLog *, PiecewisePoissonLossLog *, int);
   int check_min_of(PiecewisePoissonLossLog *, PiecewisePoissonLossLog *);

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -3,6 +3,8 @@
 #include "funPieceListLog.h"
 #include "PeakSegPDPALog.h"
 #include "PeakSegFPOPLog.h"
+#include "PoissonFPOPunconstrained.h"
+#include "NormalFPOPisotonic.h"
 #include <R.h>
 #include <R_ext/Rdynload.h>
 
@@ -44,6 +46,35 @@ void PeakSegFPOPLog_interface
   }
 }
 
+void PoissonFPOPunconstrained_interface
+(int *data_ptr, double *weight_ptr,
+ int *data_count, double *penalty,
+ double *cost_vec, int *end_vec,
+ double *mean_vec, int *intervals_vec){
+  int status = PoissonFPOPunconstrainedLog
+    (data_ptr, weight_ptr,
+     *data_count, *penalty,
+     cost_vec, end_vec, mean_vec, intervals_vec);
+  if(status == ERROR_NEGATIVE_DATA){
+    Rf_error("Negative values not allowed for Poisson loss");
+  }
+  if(status == ERROR_MIN_MAX_SAME){
+    Rf_error("data[i]=%d for all i", data_ptr[0]);
+  }
+}
+
+void NormalFPOPisotonic_interface
+(double *data_ptr, int *data_count, double *penalty,
+ double *cost_vec, int *end_vec,
+ double *mean_vec, int *intervals_vec){
+  int status = NormalFPOPisotonic
+    (data_ptr, *data_count, *penalty,
+     cost_vec, end_vec, mean_vec, intervals_vec);
+  if(status == ERROR_MIN_MAX_SAME){
+    Rf_error("data[i]=%f for all i", data_ptr[0]);
+  }
+}
+
 R_CMethodDef cMethods[] = {
   {"PeakSegPDPALog_interface",
    (DL_FUNC) &PeakSegPDPALog_interface, 8
@@ -56,6 +87,12 @@ R_CMethodDef cMethods[] = {
   {"PeakSegFPOPLog_interface",
    (DL_FUNC) &PeakSegFPOPLog_interface, 8
    //,{INTSXP, REALSXP, REALSXP, INTSXP}
+  },
+  {"PoissonFPOPunconstrained_interface",
+   (DL_FUNC) &PoissonFPOPunconstrained_interface, 8
+  },
+  {"NormalFPOPisotonic_interface",
+   (DL_FUNC) &NormalFPOPisotonic_interface, 7
   },
   {NULL, NULL, 0}
 };

--- a/tests/testthat/test-NormalFPOPisotonic.R
+++ b/tests/testthat/test-NormalFPOPisotonic.R
@@ -1,0 +1,116 @@
+library(testthat)
+library(PeakSegOptimal)
+
+expand_means <- function(result, n) {
+  fitted <- numeric(n)
+  seg.start <- 1L
+  for(k in seq_len(result$n.segments)) {
+    if(k < result$n.segments) {
+      seg.stop <- result$seg.end[k + 1L]
+    } else {
+      seg.stop <- n
+    }
+    fitted[seg.start:seg.stop] <- result$seg.mean[k]
+    seg.start <- seg.stop + 1L
+  }
+  fitted
+}
+
+test_that("strictly decreasing data gives flat mean (PAVA pooling)", {
+  y <- c(5, 4, 3, 2, 1)
+  result <- NormalFPOPisotonic(y, penalty = 0)
+  fitted <- expand_means(result, length(y))
+  expect_equal(fitted, rep(mean(y), length(y)), tolerance = 1e-6)
+})
+
+test_that("penalty=0 matches isoreg on random data", {
+  set.seed(42)
+  y <- c(5, 3, 4, 1, 2, 8, 7, 9)
+  result <- NormalFPOPisotonic(y, penalty = 0)
+  fitted <- expand_means(result, length(y))
+  iso_fitted <- as.numeric(isoreg(y)$yf)
+  expect_equal(fitted, iso_fitted, tolerance = 1e-5,
+               info = "random 8-element vector")
+})
+
+test_that("penalty=0 matches isoreg on already sorted data", {
+  y <- c(1, 2, 3, 4, 5)
+  result <- NormalFPOPisotonic(y, penalty = 0)
+  fitted <- expand_means(result, length(y))
+  iso_fitted <- as.numeric(isoreg(y)$yf)
+  expect_equal(fitted, iso_fitted, tolerance = 1e-5,
+               info = "already non-decreasing")
+})
+
+test_that("penalty=0 matches isoreg on strictly decreasing data", {
+  y <- c(10, 8, 6, 4, 2)
+  result <- NormalFPOPisotonic(y, penalty = 0)
+  fitted <- expand_means(result, length(y))
+  iso_fitted <- as.numeric(isoreg(y)$yf)
+  expect_equal(fitted, iso_fitted, tolerance = 1e-5,
+               info = "strictly decreasing")
+})
+
+test_that("penalty=0 matches isoreg on longer random data", {
+  set.seed(2026)
+  y <- rnorm(50, mean = cumsum(rnorm(50, 0, 0.3)))
+  result <- NormalFPOPisotonic(y, penalty = 0)
+  fitted <- expand_means(result, length(y))
+  iso_fitted <- as.numeric(isoreg(y)$yf)
+  expect_equal(fitted, iso_fitted, tolerance = 1e-5,
+               info = "50-point random walk")
+})
+
+test_that("n=2 works correctly", {
+  y <- c(1.0, 5.0)
+  r_low <- NormalFPOPisotonic(y, penalty = 0)
+  expect_equal(r_low$n.segments, 2L)
+  expect_equal(as.numeric(r_low$seg.mean), c(1, 5), tolerance = 1e-6)
+  r_high <- NormalFPOPisotonic(y, penalty = 1e6)
+  expect_equal(r_high$n.segments, 1L)
+  expect_equal(r_high$seg.mean[1], mean(y), tolerance = 1e-6)
+})
+
+test_that("means are always non-decreasing", {
+  set.seed(7)
+  y <- rnorm(30, mean = 0, sd = 5)
+  for (pen in c(0, 1, 5, 20, 100)) {
+    result <- NormalFPOPisotonic(y, penalty = pen)
+    if (result$n.segments > 1) {
+      expect_true(all(diff(result$seg.mean) >= -1e-8),
+                  info = paste("non-decreasing at penalty =", pen))
+    }
+  }
+})
+
+test_that("high penalty gives 1 segment at overall mean", {
+  set.seed(99)
+  y <- rnorm(40, mean = 5)
+  result <- NormalFPOPisotonic(y, penalty = 1e8)
+  expect_equal(result$n.segments, 1L)
+  expect_equal(result$seg.mean[1], mean(y), tolerance = 1e-6)
+})
+
+test_that("already isotonic data is not altered", {
+  y <- c(1.0, 2.0, 3.0, 4.0, 5.0)
+  result <- NormalFPOPisotonic(y, penalty = 0)
+  fitted <- expand_means(result, length(y))
+  iso_fitted <- as.numeric(isoreg(y)$yf)
+  expect_equal(fitted, iso_fitted, tolerance = 1e-6,
+               info = "isotonic data, penalty=0")
+})
+
+test_that("penalty=0 matches isoreg on 200 random trials (N=10)", {
+  set.seed(20260222)
+  n_fail <- 0L
+  for (trial in seq_len(200)) {
+    y <- switch(((trial - 1L) %% 3L) + 1L,
+      rnorm(10), round(runif(10, 0, 10)), rnorm(10, sd = 1e3))
+    if (length(unique(y)) < 2L) next
+    result <- NormalFPOPisotonic(y, penalty = 0)
+    fitted <- expand_means(result, length(y))
+    iso <- as.numeric(isoreg(y)$yf)
+    if (max(abs(fitted - iso)) > 1e-5) n_fail <- n_fail + 1L
+  }
+  expect_equal(n_fail, 0L)
+})

--- a/tests/testthat/test-NormalFPOPisotonic.R
+++ b/tests/testthat/test-NormalFPOPisotonic.R
@@ -100,6 +100,33 @@ test_that("already isotonic data is not altered", {
                info = "isotonic data, penalty=0")
 })
 
+if(requireNamespace("fpop", quietly = TRUE)) {
+
+  test_that("matches Fpop when unconstrained solution is non-decreasing", {
+    cases <- list(
+      list(y = c(rep(2, 20), rep(5, 20), rep(10, 20)), pens = c(1, 5, 10)),
+      list(y = c(rep(0, 10), rep(3, 10), rep(7, 10), rep(15, 10)), pens = c(1, 5, 10)),
+      list(y = c(rep(1, 30), rep(8, 30)), pens = c(1, 5, 20))
+    )
+    for (cc in cases) {
+      for (pen in cc$pens) {
+        fpop_fit <- fpop::Fpop(cc$y, lambda = pen)
+        fpop_seg_means <- unique(fpop_fit$signal)
+        if (all(diff(fpop_seg_means) >= -1e-8)) {
+          iso_fit <- NormalFPOPisotonic(cc$y, penalty = pen)
+          iso_fitted <- expand_means(iso_fit, length(cc$y))
+          expect_equal(iso_fitted, as.numeric(fpop_fit$signal),
+                       tolerance = 1e-5,
+                       info = paste("n =", length(cc$y), "pen =", pen))
+        }
+      }
+    }
+  })
+
+} else {
+  message("fpop not installed, skipping Fpop comparison tests")
+}
+
 test_that("penalty=0 matches isoreg on 200 random trials (N=10)", {
   set.seed(20260222)
   n_fail <- 0L

--- a/tests/testthat/test-NormalFPOPisotonic.R
+++ b/tests/testthat/test-NormalFPOPisotonic.R
@@ -1,4 +1,5 @@
 library(testthat)
+context("NormalFPOPisotonic")
 library(PeakSegOptimal)
 
 expand_means <- function(result, n) {

--- a/tests/testthat/test-PoissonFPOPunconstrained.R
+++ b/tests/testthat/test-PoissonFPOPunconstrained.R
@@ -2,17 +2,6 @@ library(testthat)
 context("PoissonFPOPunconstrained")
 library(PeakSegOptimal)
 
-select_segmentor_model <- function(seg, penalty) {
-  costs <- seg@likelihood
-  K_values <- seq_len(nrow(costs))
-  penalized <- costs[,1] + penalty * (K_values - 1)
-  best_K <- which.min(penalized)
-  breaks <- Segmentor3IsBack::getBreaks(seg)[best_K, seq_len(best_K)]
-  means  <- Segmentor3IsBack::getParameters(seg)[best_K, seq_len(best_K)]
-  list(K = best_K, breaks = breaks, means = means,
-       cost = costs[best_K, 1])
-}
-
 fpop_to_breaks <- function(result, n) {
   K <- result$n.segments
   if(K == 1) return(n)
@@ -32,74 +21,6 @@ expand_means <- function(result, n) {
     seg.start <- seg.stop + 1L
   }
   fitted
-}
-
-if(requireNamespace("Segmentor3IsBack", quietly = TRUE)) {
-
-  test_that("3-segment Poisson data matches Segmentor", {
-    set.seed(42)
-    data_vec <- as.integer(c(rpois(30, 5), rpois(30, 20), rpois(30, 5)))
-    n <- length(data_vec)
-    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 30)
-    for (pen in c(5, 10, 50, 100)) {
-      fpop <- PoissonFPOPunconstrained(data_vec, penalty = pen)
-      segm <- select_segmentor_model(seg, pen)
-      fpop_breaks <- fpop_to_breaks(fpop, n)
-      expect_identical(as.integer(fpop$n.segments), as.integer(segm$K),
-                       info = paste("n.segments at penalty =", pen))
-      expect_identical(as.integer(fpop_breaks), as.integer(segm$breaks),
-                       info = paste("breaks at penalty =", pen))
-    }
-  })
-
-  test_that("single changepoint data matches Segmentor", {
-    set.seed(123)
-    data_vec <- as.integer(c(rpois(50, 3), rpois(50, 15)))
-    n <- length(data_vec)
-    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 20)
-    for (pen in c(10, 50, 200)) {
-      fpop <- PoissonFPOPunconstrained(data_vec, penalty = pen)
-      segm <- select_segmentor_model(seg, pen)
-      fpop_breaks <- fpop_to_breaks(fpop, n)
-      expect_identical(as.integer(fpop$n.segments), as.integer(segm$K),
-                       info = paste("n.segments at penalty =", pen))
-      expect_identical(as.integer(fpop_breaks), as.integer(segm$breaks),
-                       info = paste("breaks at penalty =", pen))
-    }
-  })
-
-  test_that("constant-rate data gives 1 segment at high penalty", {
-    set.seed(7)
-    data_vec <- as.integer(rpois(80, 10))
-    n <- length(data_vec)
-    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 10)
-    fpop <- PoissonFPOPunconstrained(data_vec, penalty = 500)
-    segm <- select_segmentor_model(seg, 500)
-    expect_identical(as.integer(fpop$n.segments), 1L)
-    expect_identical(as.integer(fpop$n.segments), as.integer(segm$K))
-  })
-
-  test_that("many-changepoint data matches Segmentor at low penalty", {
-    set.seed(99)
-    data_vec <- as.integer(c(
-      rpois(20, 2), rpois(20, 15), rpois(20, 4),
-      rpois(20, 25), rpois(20, 3)
-    ))
-    n <- length(data_vec)
-    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 30)
-    for (pen in c(1, 5, 20, 100)) {
-      fpop <- PoissonFPOPunconstrained(data_vec, penalty = pen)
-      segm <- select_segmentor_model(seg, pen)
-      fpop_breaks <- fpop_to_breaks(fpop, n)
-      expect_identical(as.integer(fpop$n.segments), as.integer(segm$K),
-                       info = paste("n.segments at penalty =", pen))
-      expect_identical(as.integer(fpop_breaks), as.integer(segm$breaks),
-                       info = paste("breaks at penalty =", pen))
-    }
-  })
-
-} else {
-  message("Segmentor3IsBack not installed, skipping comparison tests")
 }
 
 test_that("penalty=0 gives every point its own segment", {

--- a/tests/testthat/test-PoissonFPOPunconstrained.R
+++ b/tests/testthat/test-PoissonFPOPunconstrained.R
@@ -1,4 +1,5 @@
 library(testthat)
+context("PoissonFPOPunconstrained")
 library(PeakSegOptimal)
 
 select_segmentor_model <- function(seg, penalty) {

--- a/tests/testthat/test-PoissonFPOPunconstrained.R
+++ b/tests/testthat/test-PoissonFPOPunconstrained.R
@@ -1,0 +1,120 @@
+library(testthat)
+library(PeakSegOptimal)
+
+select_segmentor_model <- function(seg, penalty) {
+  costs <- seg@likelihood
+  K_values <- seq_len(nrow(costs))
+  penalized <- costs[,1] + penalty * (K_values - 1)
+  best_K <- which.min(penalized)
+  breaks <- Segmentor3IsBack::getBreaks(seg)[best_K, seq_len(best_K)]
+  means  <- Segmentor3IsBack::getParameters(seg)[best_K, seq_len(best_K)]
+  list(K = best_K, breaks = breaks, means = means,
+       cost = costs[best_K, 1])
+}
+
+fpop_to_breaks <- function(result, n) {
+  K <- result$n.segments
+  if(K == 1) return(n)
+  c(result$seg.end[2:K], n)
+}
+
+expand_means <- function(result, n) {
+  fitted <- numeric(n)
+  seg.start <- 1L
+  for(k in seq_len(result$n.segments)) {
+    if(k < result$n.segments) {
+      seg.stop <- result$seg.end[k + 1L]
+    } else {
+      seg.stop <- n
+    }
+    fitted[seg.start:seg.stop] <- result$seg.mean[k]
+    seg.start <- seg.stop + 1L
+  }
+  fitted
+}
+
+if(requireNamespace("Segmentor3IsBack", quietly = TRUE)) {
+
+  test_that("3-segment Poisson data matches Segmentor", {
+    set.seed(42)
+    data_vec <- as.integer(c(rpois(30, 5), rpois(30, 20), rpois(30, 5)))
+    n <- length(data_vec)
+    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 30)
+    for (pen in c(5, 10, 50, 100)) {
+      fpop <- PoissonFPOPunconstrained(data_vec, penalty = pen)
+      segm <- select_segmentor_model(seg, pen)
+      fpop_breaks <- fpop_to_breaks(fpop, n)
+      expect_identical(as.integer(fpop$n.segments), as.integer(segm$K),
+                       info = paste("n.segments at penalty =", pen))
+      expect_identical(as.integer(fpop_breaks), as.integer(segm$breaks),
+                       info = paste("breaks at penalty =", pen))
+    }
+  })
+
+  test_that("single changepoint data matches Segmentor", {
+    set.seed(123)
+    data_vec <- as.integer(c(rpois(50, 3), rpois(50, 15)))
+    n <- length(data_vec)
+    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 20)
+    for (pen in c(10, 50, 200)) {
+      fpop <- PoissonFPOPunconstrained(data_vec, penalty = pen)
+      segm <- select_segmentor_model(seg, pen)
+      fpop_breaks <- fpop_to_breaks(fpop, n)
+      expect_identical(as.integer(fpop$n.segments), as.integer(segm$K),
+                       info = paste("n.segments at penalty =", pen))
+      expect_identical(as.integer(fpop_breaks), as.integer(segm$breaks),
+                       info = paste("breaks at penalty =", pen))
+    }
+  })
+
+  test_that("constant-rate data gives 1 segment at high penalty", {
+    set.seed(7)
+    data_vec <- as.integer(rpois(80, 10))
+    n <- length(data_vec)
+    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 10)
+    fpop <- PoissonFPOPunconstrained(data_vec, penalty = 500)
+    segm <- select_segmentor_model(seg, 500)
+    expect_identical(as.integer(fpop$n.segments), 1L)
+    expect_identical(as.integer(fpop$n.segments), as.integer(segm$K))
+  })
+
+  test_that("many-changepoint data matches Segmentor at low penalty", {
+    set.seed(99)
+    data_vec <- as.integer(c(
+      rpois(20, 2), rpois(20, 15), rpois(20, 4),
+      rpois(20, 25), rpois(20, 3)
+    ))
+    n <- length(data_vec)
+    seg <- Segmentor3IsBack::Segmentor(data_vec, model = 1, Kmax = 30)
+    for (pen in c(1, 5, 20, 100)) {
+      fpop <- PoissonFPOPunconstrained(data_vec, penalty = pen)
+      segm <- select_segmentor_model(seg, pen)
+      fpop_breaks <- fpop_to_breaks(fpop, n)
+      expect_identical(as.integer(fpop$n.segments), as.integer(segm$K),
+                       info = paste("n.segments at penalty =", pen))
+      expect_identical(as.integer(fpop_breaks), as.integer(segm$breaks),
+                       info = paste("breaks at penalty =", pen))
+    }
+  })
+
+} else {
+  message("Segmentor3IsBack not installed, skipping comparison tests")
+}
+
+test_that("penalty=0 gives every point its own segment", {
+  data_vec <- as.integer(c(3, 10, 3, 10, 3))
+  fpop <- PoissonFPOPunconstrained(data_vec, penalty = 0.0)
+  expect_identical(as.integer(fpop$n.segments), length(data_vec))
+})
+
+test_that("n=2 works for both 1-segment and 2-segment outcomes", {
+  data_vec <- as.integer(c(1, 100))
+  fpop2 <- PoissonFPOPunconstrained(data_vec, penalty = 0.0)
+  expect_identical(as.integer(fpop2$n.segments), 2L)
+  fpop1 <- PoissonFPOPunconstrained(data_vec, penalty = 1e10)
+  expect_identical(as.integer(fpop1$n.segments), 1L)
+})
+
+test_that("rejects negative data", {
+  expect_error(PoissonFPOPunconstrained(as.integer(c(-1, 2, 3)), penalty = 5))
+})


### PR DESCRIPTION
Two new FPOP solvers for the GSoC 2026 gfpop tests:

- `PoissonFPOPunconstrained`: unconstrained optimal partitioning (Poisson loss). Collapses the 2-state up/down model to 1 state, replaces monotonicity operators with `set_to_unconstrained_min_of`. Validated against `Segmentor3IsBack::Segmentor(model=1)`.
- `NormalFPOPisotonic`: regularized isotonic regression (Normal loss). Uses `set_to_min_less_of` for non-decreasing constraint. `NormalLossPiece` inherits from a shared `LossPiece` base class alongside `PoissonLossPieceLog`. Validated against `isoreg()` (penalty=0) and `fpop::Fpop()`.

New files: `src/PoissonFPOPunconstrained.{cpp,h}`, `src/NormalFPOPisotonic.{cpp,h}`, `src/LossPiece.h`, `R/PoissonFPOPunconstrained.R`, `R/NormalFPOPisotonic.R`, `man/PoissonFPOPunconstrained.Rd`, `man/NormalFPOPisotonic.Rd`, `tests/testthat/test-PoissonFPOPunconstrained.R` (28 tests), `tests/testthat/test-NormalFPOPisotonic.R` (17 tests).

Modified: `src/funPieceListLog.{h,cpp}` (added `set_to_unconstrained_min_of`), `src/interface.cpp` (registered new C entry points), `README.org`.

Passes `R CMD check --no-manual` with no new warnings.